### PR TITLE
cd to arg if it's a dir and not in DB

### DIFF
--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -568,7 +568,7 @@ zshz() {
     return 1
   fi
 
-  local opt output_format method='frecency' fnd prefix
+  local opt output_format method='frecency' fnd prefix req
 
   for opt in ${(k)opts}; do
     case $opt in
@@ -664,7 +664,7 @@ zshz() {
     fi
   else
     if [[ -z $output_format && -d $req ]]; then
-      cd "$req"
+      builtin cd "$req"
     else
       return $ret2
     fi

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -568,7 +568,7 @@ zshz() {
     return 1
   fi
 
-  local opt output_format method='frecency' fnd
+  local opt output_format method='frecency' fnd prefix
 
   for opt in ${(k)opts}; do
     case $opt in
@@ -583,7 +583,7 @@ zshz() {
         fi
         output_format='completion'
         ;;
-      -c) [[ $* == ${PWD}/* || $PWD == '/' ]] || set -- "$PWD $*" ;;
+      -c) [[ $* == ${PWD}/* || $PWD == '/' ]] || prefix="$PWD " ;;
       -h|--help)
         _zshz_usage
         return
@@ -597,7 +597,8 @@ zshz() {
         ;;
     esac
   done
-  fnd="$*"
+  req="$*"
+  fnd="$prefix$*"
 
   [[ -n $fnd && $fnd != "$PWD " ]] || {
     [[ $output_format != 'completion' ]] && output_format='list'
@@ -662,8 +663,8 @@ zshz() {
       [[ -d $cd ]] && builtin cd "$cd"
     fi
   else
-    if [[ -d $fnd ]]; then
-      builtin cd "$fnd"
+    if [[ -z $output_format && -d $req ]]; then
+      cd "$req"
     else
       return $ret2
     fi

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -662,7 +662,11 @@ zshz() {
       [[ -d $cd ]] && builtin cd "$cd"
     fi
   else
-    return $ret2
+    if [[ -d $fnd ]]; then
+      builtin cd "$fnd"
+    else
+      return $ret2
+    fi
   fi
 }
 


### PR DESCRIPTION
When `z` DB is empty, `z ~/Downloads` goes to the `~/Downloads` directory, while `z Downloads` issued from `~` returns an error code. Why not use `cd` on arguments that are correct relative paths?