### PR TITLE
Use escaped path when accessing accociative array

### DIFF
--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -575,14 +575,18 @@ zshz() {
         imatches[$path_field]=$rank
       fi
 
-      if (( matches[$path_field] )) &&
-         (( matches[$path_field] > hi_rank )); then
+      # Escape characters that would cause "invalid subscript" errors
+      # when accessing the associative array.
+      escaped_path_field=${(b)path_field}
+
+      if (( matches[$escaped_path_field] )) &&
+         (( matches[$escaped_path_field] > hi_rank )); then
         best_match=$path_field
-        hi_rank=${matches[$path_field]}
-      elif (( imatches[$path_field] )) &&
-           (( imatches[$path_field] > ihi_rank )); then
+        hi_rank=${matches[$escaped_path_field]}
+      elif (( imatches[$escaped_path_field] )) &&
+           (( imatches[$escaped_path_field] > ihi_rank )); then
         ibest_match=$path_field
-        ihi_rank=${imatches[$path_field]}
+        ihi_rank=${imatches[$escaped_path_field]}
         ZSHZ[CASE_INSENSITIVE]=1
       fi
     done


### PR DESCRIPTION
Started noticing `invalid subscript` errors suddenly and realized it had to be a new path that was added. Zsh associative arrays are not very nice when dealing with certain characters, unfortunately :(.

The problems seems to be limited to accessing/reading from the array, though, so in my limited testing, this patch seems sufficient but there may be other problems I've overlooked.

Issue reproduction (without patch):

```zsh
❯ mkdir -p 'test (paren)/[hello/world[]' && cd $_
❯ z paren hello world
_zshz_find_matches:66: invalid subscript
_zshz_find_matches:70: invalid subscript
_zshz_find_matches:66: invalid subscript
_zshz_find_matches:70: invalid subscript
_zshz_find_matches:66: invalid subscript
_zshz_find_matches:70: invalid subscript
_zshz_find_matches:66: invalid subscript
_zshz_find_matches:70: invalid subscript
```

For reference, stack exchange question about deleting keys with special characters from an associative array: https://unix.stackexchange.com/questions/626393/in-zsh-how-do-i-unset-an-arbitrary-associative-array-element