### PR TITLE
Use the standard oh-my-zsh plugin install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ to your `.zshrc`, somewhere above the line that says `antigen apply`.
 
 Execute the following command:
 
-    git clone https://github.com/agkozak/zsh-z $ZSH_CUSTOM/plugins/zsh-z
+    git clone https://github.com/agkozak/zsh-z ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-z
 
 and add `zsh-z` to the line of your `.zshrc` that specifies `plugins=()`, e.g., `plugins=( git zsh-z )`.
 


### PR DESCRIPTION
Mirror of #64, which was mistakenly closed

> This PR changes the oh-my-zsh installation instructions to the one most commonly used which includes a default for the envvar
> Some examples:
>>    https://github.com/zsh-users/zsh-autosuggestions/blob/master/INSTALL.md#oh-my-zsh
>>    https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/INSTALL.md#oh-my-zsh
>>    https://github.com/Aloxaf/fzf-tab#oh-my-zsh


