### PR TITLE
Intruduce ZSHZ_CD variable that allows to change the 'builtin cd' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Zsh-z is a drop-in replacement for `rupa/z` and will, by default, use the same d
 <details>
     <summary>Here are the latest features and updates.</summary>
 
+- January 31, 2023
+    + Zsh-z now allows to overwrite the default `cd` command using the `ZSHZ_CD` environment variable, if unset `builtin cd` is used (props @basnijholt).
 - January 27, 2023
     + If the datafile directory specified by `ZSHZ_DATA` or `_Z_DATA` does not already exist, create it (props @mattmc3).
 - June 29, 2022
@@ -260,6 +262,7 @@ to install `zsh-z`.
 Zsh-z has environment variables (they all begin with `ZSHZ_`) that change its behavior if you set them; you can also keep your old ones if you have been using `rupa/z` (they begin with `_Z_`).
 
 * `ZSHZ_CMD` changes the command name (default: `z`)
+* `ZSHZ_CD` sets the `cd` command that is used (default: `builtin cd`)
 * `ZSHZ_COMPLETION` can be `'frecent'` (default) or `'legacy'`, depending on whether you want your completion results sorted according to frecency or simply sorted alphabetically
 * `ZSHZ_DATA` changes the database file (default: `~/.z`)
 * `ZSHZ_ECHO` displays the new path name when changing directories (default: `0`)

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -52,6 +52,7 @@
 #   ZSHZ_CASE -> if `ignore', pattern matching is case-insensitive; if `smart',
 #     pattern matching is case-insensitive only when the pattern is all
 #     lowercase
+#   ZSHZ_CD -> the cd command that is used (default: builtin cd)
 #   ZSHZ_CMD -> name of command (default: z)
 #   ZSHZ_COMPLETION -> completion method (default: 'frecent'; 'legacy' for
 #     alphabetic sorting)
@@ -129,6 +130,7 @@ is-at-least 5.3.0 && ZSHZ[PRINTV]=1
 # Globals:
 #   ZSHZ
 #   ZSHZ_CASE
+#   ZSHZ_CD
 #   ZSHZ_COMPLETION
 #   ZSHZ_DATA
 #   ZSHZ_DEBUG
@@ -767,6 +769,14 @@ zshz() {
   }
 
   #########################################################
+  # If $ZSHZ_CD is empty set it to $(builtin cd) otherwise
+  # use the function defined by the user.
+  #########################################################
+  if [[ -z $ZSHZ_CD ]]; then
+    ZSHZ_CD=$(builtin cd)
+  fi
+
+  #########################################################
   # If $ZSHZ_ECHO == 1, display paths as you jump to them.
   # If it is also the case that $ZSHZ_TILDE == 1, display
   # the home directory as a tilde.
@@ -783,7 +793,7 @@ zshz() {
 
   if [[ ${@: -1} == /* ]] && (( ! $+opts[-e] && ! $+opts[-l] )); then
     # cd if possible; echo the new path if $ZSHZ_ECHO == 1
-    [[ -d ${@: -1} ]] && builtin cd ${@: -1} && _zshz_echo && return
+    [[ -d ${@: -1} ]] && $ZSHZ_CD ${@: -1} && _zshz_echo && return
   fi
 
   # With option -c, make sure query string matches beginning of matches;
@@ -840,12 +850,12 @@ zshz() {
       print -- "$cd"
     else
       # cd if possible; echo the new path if $ZSHZ_ECHO == 1
-      [[ -d $cd ]] && builtin cd "$cd" && _zshz_echo
+      [[ -d $cd ]] && $ZSHZ_CD "$cd" && _zshz_echo
     fi
   else
     # if $req is a valid path, cd to it; echo the new path if $ZSHZ_ECHO == 1
     if ! (( $+opts[-e] || $+opts[-l] )) && [[ -d $req ]]; then
-      builtin cd "$req" && _zshz_echo
+      $ZSHZ_CD "$req" && _zshz_echo
     else
       return $ret2
     fi

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -769,11 +769,11 @@ zshz() {
   }
 
   #########################################################
-  # If $ZSHZ_CD is empty set it to $(builtin cd) otherwise
+  # If $ZSHZ_CD is empty set it to `builtin cd` otherwise
   # use the function defined by the user.
   #########################################################
   if [[ -z $ZSHZ_CD ]]; then
-    ZSHZ_CD=$(builtin cd)
+    typeset -g ZSHZ_CD='builtin cd'
   fi
 
   #########################################################
@@ -793,7 +793,7 @@ zshz() {
 
   if [[ ${@: -1} == /* ]] && (( ! $+opts[-e] && ! $+opts[-l] )); then
     # cd if possible; echo the new path if $ZSHZ_ECHO == 1
-    [[ -d ${@: -1} ]] && $ZSHZ_CD ${@: -1} && _zshz_echo && return
+    [[ -d ${@: -1} ]] && ${=ZSHZ_CD} ${@: -1} && _zshz_echo && return
   fi
 
   # With option -c, make sure query string matches beginning of matches;
@@ -850,12 +850,12 @@ zshz() {
       print -- "$cd"
     else
       # cd if possible; echo the new path if $ZSHZ_ECHO == 1
-      [[ -d $cd ]] && $ZSHZ_CD "$cd" && _zshz_echo
+      [[ -d $cd ]] && ${=ZSHZ_CD} "$cd" && _zshz_echo
     fi
   else
     # if $req is a valid path, cd to it; echo the new path if $ZSHZ_ECHO == 1
     if ! (( $+opts[-e] || $+opts[-l] )) && [[ -d $req ]]; then
-      $ZSHZ_CD "$req" && _zshz_echo
+      ${=ZSHZ_CD} "$req" && _zshz_echo
     else
       return $ret2
     fi


### PR DESCRIPTION
Allows to solve issues like reported in https://github.com/hyperupcall/autoenv/issues/154.

This introduces an environment variable `ZSHZ_CD` which can be set to something else than the default `builtin cd` command.

For example, when using with `autoenv`, one uses:
```
export ZSHZ_CD=cd
```
or `export ZSHZ_CD=autoenv_cd` to be more explicit.
