### PR TITLE
add fuzzy matching completion

### DIFF
--- a/_zshz
+++ b/_zshz
@@ -55,7 +55,7 @@ emulate -L zsh
 local completions expl completion
 local -a completion_list
 
-completions=$(zshz --complete ${(@)words:1})
+completions=$(zshz --complete ${(j: :)${(s::)${${(@)words:1}// /}}})
 [[ -z $completions ]] && return 1
 
 for completion in ${(f)completions[@]}; do


### PR DESCRIPTION
this commit adds a kind of fuzzy matching to zsh. example:

zshz <TAB> -> agkozak/zsh-z

this was not possible before.

If you do not want it to be the default behavior, I can add a flag to make it optional, for example `ZSHZ_FUZZY`.