### PR TITLE
XDG compliance

### DIFF
--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -170,7 +170,19 @@ zshz() {
     exit
   fi
 
-  # If the user specified a datafile, use that or default to ~/.z
+  # Use $XDG_STATE_HOME/.z as the default
+  default_datafile="${XDG_STATE_HOME:-$HOME/.local/state}/.z"
+
+  # For backwards compatability, perform a one-time copy from $HOME/.z to $default_datafile if:
+  # - $default_datafile doesn't exist
+  # - $HOME/.z exists and meets the ownership requirements
+  # - $custom_datafile is not being used.
+  if [[ -z "$custom_datafile" && ! -f "$default_datafile" && -f "$HOME/.z" && -z ${ZSHZ_OWNER:-${_Z_OWNER}} && ! -O "$HOME/.z" ]]; then
+    mkdir -p "${default_datafile:h}" && cp "$HOME/.z" "$default_datafile"
+  fi
+
+  local datafile=${${custom_datafile:-$default_datafile}:A}
+  # If the user specified a datafile, use that or default to $XDG_STATE_HOME/.z
   # If the datafile is a symlink, it gets dereferenced
   local datafile=${${custom_datafile:-$HOME/.z}:A}
 


### PR DESCRIPTION
zsh-z's .z file should be [XDG_COMPLIANT](https://specifications.freedesktop.org/basedir-spec/latest/)
> $XDG_DATA_HOME defines the base directory relative to which user-specific data files should be stored. If $XDG_DATA_HOME is either not set or empty, a default equal to $HOME/.local/share should be used.
>
>$XDG_STATE_HOME defines the base directory relative to which user-specific state files should be stored. If $XDG_STATE_HOME is either not set or empty, a default equal to $HOME/.local/state should be used.
>
> The $XDG_STATE_HOME contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in $XDG_DATA_HOME. It may contain:
> - actions history (logs, history, recently used files, …)
> - current state of the application that can be reused on a restart (view, layout, open files, undo history, …)


Resolves #20 

