### PR TITLE
Respect $ZDOTDIR on installation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Zsh-z has environment variables (they all begin with `ZSHZ_`) that change its be
 * `ZSHZ_CMD` changes the command name (default: `z`)
 * `ZSHZ_CD` specifies the default directory-changing command (default: `builtin cd`)
 * `ZSHZ_COMPLETION` can be `'frecent'` (default) or `'legacy'`, depending on whether you want your completion results sorted according to frecency or simply sorted alphabetically
-* `ZSHZ_DATA` changes the database file (default: `~/.z`)
+* `ZSHZ_DATA` changes the database file (default: `$ZDOTDIR/.z` falls back to `~/.z`)
 * `ZSHZ_ECHO` displays the new path name when changing directories (default: `0`)
 * `ZSHZ_EXCLUDE_DIRS` is an array of directories to keep out of the database (default: empty)
 * `ZSHZ_KEEP_DIRS` is an array of directories that should not be removed from the database, even if they are not currently available (useful when a drive is not always mounted) (default: empty)

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -56,7 +56,7 @@
 #   ZSHZ_CMD -> name of command (default: z)
 #   ZSHZ_COMPLETION -> completion method (default: 'frecent'; 'legacy' for
 #     alphabetic sorting)
-#   ZSHZ_DATA -> name of datafile (default: ~/.z)
+#   ZSHZ_DATA -> name of datafile (default: $ZDOTDIR/.z else ~/.z)
 #   ZSHZ_EXCLUDE_DIRS -> array of directories to exclude from your database
 #     (default: empty)
 #   ZSHZ_KEEP_DIRS -> array of directories that should not be removed from the

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -170,9 +170,12 @@ zshz() {
     exit
   fi
 
-  # If the user specified a datafile, use that or default to ~/.z
+  # If the user specified a datafile, use it else default to $ZDOTDIR/.z otherwise default to $HOME/.z
   # If the datafile is a symlink, it gets dereferenced
-  local datafile=${${custom_datafile:-$HOME/.z}:A}
+  local datafile=$custom_datafile
+  : ${datafile:=$HOME/.z}
+  [[ -f $datafile ]] || datafile=${ZDOTDIR:-$HOME}/.z
+  datafile=${datafile:A}
 
   # If the datafile is a directory, print a warning and exit
   if [[ -d $datafile ]]; then


### PR DESCRIPTION
This conforms to ZSH behavior on where to put ZSH files. 
As `$ZDOTDIR` is where things like `.zshrc` and `.zsh_history`  is stored.

For majority of users `$ZDOTDIR` will = `$HOME` thus the default location is preserved.

If user has changed `$ZDOTDIR` to say `$HOME/.config/zsh` then upon this plugin's installation, `.z` will be in `$HOME/.config/zsh` 

To avoid breakage for users who have set a custom `$ZDOTDIR` to something other than `$HOME`. but haven't changed the default database location of `$HOME/.z` 
We do this:
```zsh
: ${datafile:=$HOME/.z}
  [[ -f $datafile ]] || datafile=${ZDOTDIR:-$HOME}/.z
  ```
So even if `$ZDOTDIR` has been customized, we still default to the default database file location if it exists.

And thank you for making this plugin. Its very much appreciated. 