### PR TITLE
Add test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install zsh (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh
+
+      - name: Show zsh version
+        run: zsh --version
+
+      - name: Syntax check
+        run: |
+          zsh -n zsh-z.plugin.zsh
+          zsh -n _zshz
+
+      - name: Run tests
+        run: zsh tests/run.zsh

--- a/_zshz
+++ b/_zshz
@@ -27,8 +27,6 @@
 #
 # z (https://github.com/rupa/z) is copyright (c) 2009 rupa deadwyler and
 # licensed under the WTFPL license, Version 2.a
-#
-# shellcheck shell=ksh
 
 ############################################################
 # Zsh-z COMPLETIONS

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -407,6 +407,37 @@ preserves them.
 - `test_common_root_single_match_returns_full_path` — degenerate
   single-match case.
 
+### `test_complete_aliases.zsh` — tab completion under `setopt COMPLETE_ALIASES`
+
+`compinit` parses the static `#compdef` tag in `_zshz` literally, so the
+`${ZSHZ_CMD:-...}` part of the tag is never expanded and only the literal
+`zshz` command gets registered. Without `COMPLETE_ALIASES` that's fine
+(zsh expands the alias to `zshz` before looking up `_comps[zshz]`); under
+`COMPLETE_ALIASES` the lookup is verbatim and would miss `_zshz`. The
+widget compensates by populating `_comps[$cmd]` on first invocation,
+guarded so a user-defined completer for the same name isn't clobbered.
+
+Tests stub `zle` to a no-op and invoke `_zshz_zle_completion_widget`
+directly (same pattern as `test_widget.zsh`) so the registration branch
+can be exercised without a real ZLE session.
+
+- `test_alias_is_defined_after_sourcing` — sanity: `aliases[z]` is
+  `zshz 2>&1` after the plugin is sourced.
+- `test_static_compdef_registers_zshz_literal` — sanity: `compinit`
+  picks up the literal `zshz` from the `#compdef` tag, which is what
+  makes completion work in the common no-`COMPLETE_ALIASES` case.
+- `test_widget_registers_alias_on_first_invocation` — without
+  `COMPLETE_ALIASES`, one widget call still binds `_comps[z]` to
+  `_zshz` (the registration runs regardless of the option).
+- `test_widget_registers_alias_under_complete_aliases` — the headline
+  scenario: `COMPLETE_ALIASES` set, one widget call leaves
+  `_comps[z] = _zshz`.
+- `test_widget_registers_alias_for_custom_ZSHZ_CMD` — with
+  `ZSHZ_CMD=zoo`, the widget binds `_comps[zoo]`, not `_comps[z]`.
+- `test_widget_does_not_overwrite_existing_comps_entry` — if the user
+  has pre-set `_comps[z]` to another completer, the
+  `(( ${+_comps[$cmd]} )) ||` guard must defer rather than clobber.
+
 ### `test_completion_legacy.zsh` — legacy completion mode
 
 - `test_legacy_complete_returns_matches` — `ZSHZ_COMPLETION=legacy`

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -1,0 +1,1026 @@
+# Zsh-z test suite
+
+Aimed at contributors authoring or reviewing tests for `zsh-z`.
+
+The suite lives on the `tests` branch of the repository (it is merged
+into branches that need to run CI against it). Everything under
+`tests/` is sourced into a single zsh process per run, with each test
+function executed inside an isolated subshell.
+
+## Running the suite
+
+```sh
+zsh tests/run.zsh                              # everything (fast tests)
+zsh tests/run.zsh test_concurrent_add_no_lost_updates  # one test
+zsh tests/run.zsh 'test_concurrent_*'          # glob match
+ZSHZ_HEAVY_TESTS=1 zsh tests/run.zsh 'test_large_*'    # opt-in heavy tests
+~/zsh/4.3.11/bin/zsh tests/run.zsh             # against an alternate zsh
+tests/stress.sh ~/bin/zsh-4.3.11               # cross-process stress driver
+```
+
+The runner invokes whichever `zsh` it was started under, so to
+exercise both supported versions you run it twice (CI does this on
+ubuntu and macOS via `.github/workflows/test.yml`).
+
+The suite has been verified on WSL2 Ubuntu (zsh 5.9 and 4.3.11),
+Solaris 11.4, FreeBSD, and MSYS2. Cygwin runs cleanly modulo one
+test that skips because `zpty -b` can't acquire a pty there.
+MobaXterm's Cygwin doesn't ship `zsh/system` at all, so the five
+flock-dependent concurrency tests also skip there — the plugin's
+no-lock fallback genuinely can't serialize cross-process writers,
+so the tests gate on `(( ZSHZ[USE_FLOCK] ))`. MSYS2 reports
+`$OSTYPE=cygwin` but ignores `chmod` on its Windows-backed
+filesystem, so the four mode-checking tests in `test_permissions.zsh`
+skip there via a runtime probe rather than an `$OSTYPE` match.
+
+## How `tests/run.zsh` runs a test
+
+1. The zsh glob `"$TESTS_DIR"/test_*.zsh(.N)` collects every test
+   file in sorted order; `run.zsh` then sources each in turn. (zsh
+   globs are sorted by default, so no separate `sort` is needed.
+   The previous `find -maxdepth 1` form isn't portable to
+   AT&T-derived `find` on Solaris.)
+2. Every function whose name starts with `test_` becomes a test. They
+   are sorted by name so execution order is stable.
+3. Optional command-line arguments are treated as **globs against
+   function names** (each arg is matched independently, ANY-match
+   semantics).
+4. For each test the runner does:
+   - `mktemp -d` to a fresh `$TESTDIR`,
+   - exports `ZSHZ_DATA="$TESTDIR/.z"`,
+   - runs the function inside `( ZSHZ_DEBUG=1; cd "$TESTDIR"; "$fn" )`
+     so cd / env / option changes never leak,
+   - captures stdout to `$STDOUT_LOG`, stderr to `$STDERR_LOG`,
+   - removes the tempdir afterward.
+5. A test is reported `PASS` if and only if **both** are true:
+   - the function returned 0,
+   - **stderr is empty**.
+
+The "stderr is empty" rule is doing real work. `WARN_CREATE_GLOBAL`,
+`NO_UNSET` warnings, "parameter not set" messages, accidental
+`echo >&2`s, and external-command errors all surface as test failures
+without any explicit assertion. Tests that legitimately call commands
+which write to stderr must redirect that stderr away (`2>/dev/null`)
+or capture it (`2>&1` inside `$(...)`).
+
+A test sets `ZSHZ_DEBUG=1`, which causes `zshz()` to additionally
+`setopt LOCAL_OPTIONS WARN_CREATE_GLOBAL`. Any code path that
+accidentally creates a global from inside `zshz` will print a
+warning, which then fails the test under the stderr rule.
+
+## Environment a test sees
+
+| Variable | Set by | What it points at |
+|---|---|---|
+| `$TESTDIR` | runner, per test | A fresh tempdir; cleaned up afterwards |
+| `$ZSHZ_DATA` | runner, per test | `$TESTDIR/.z`; auto-created by the plugin on first call |
+| `$PLUGIN_DIR` | runner, once at startup | The repository root (parent of `tests/`) |
+| `$TESTS_DIR` | runner, once at startup | The directory containing `run.zsh` |
+| `$PWD` | runner, per test | `$TESTDIR` (the test runs after `cd "$TESTDIR"`) |
+| `$ZSHZ_DEBUG` | runner, per test | `1` |
+| `setopt EXTENDED_GLOB` | runner, globally | On (so glob qualifiers like `(N)` work in tests) |
+
+The plugin is sourced **once** by `run.zsh` before any test runs, so
+its functions (`zshz`, `_zshz_precmd`, `_zshz_chpwd`,
+`_zshz_zle_completion_widget`) and globals (`ZSHZ`, `ZSHZ_*`) are
+visible to every test. Tests that need to verify *sourcing* behavior
+(e.g. emulation modes, strict options) explicitly spawn a child shell
+and source the plugin there.
+
+## Helpers in `test_helpers.zsh`
+
+Always available in every test (sourced by `run.zsh`).
+
+### Assertions
+
+All assertions use `fail` to write a single indented line to stderr
+on failure (which the runner reports under `--- stderr ---`).
+
+- `fail MESSAGE` — write to stderr, return 1.
+- `assert_eq EXPECTED ACTUAL [MSG]` — string equality.
+- `assert_ne UNEXPECTED ACTUAL [MSG]` — string inequality.
+- `assert_contains NEEDLE HAYSTACK [MSG]` — substring match.
+- `assert_not_contains NEEDLE HAYSTACK [MSG]` — substring absence.
+- `assert_file_exists PATH` — `[[ -f PATH ]]`.
+
+### Datafile inspection
+
+- `zshz_rank_of PATH` — print the rank field for PATH from
+  `$ZSHZ_DATA`, or empty string if the path isn't there or the
+  datafile doesn't exist. Implemented as `awk -F'|'`.
+- `zshz_dump` — print the entire datafile sorted by path (stable
+  output for diffing).
+
+### Datafile seeding
+
+- `zshz_seed PATH RANK [SECONDS_AGO]` — append a synthetic
+  `PATH|RANK|TIMESTAMP` line to `$ZSHZ_DATA`. `SECONDS_AGO` defaults
+  to 0 (now). Useful for setting up scenarios that would take many
+  real `--add` calls to produce.
+
+### Spawning fresh shells
+
+- `zshz_in_fresh_shell BODY` — run BODY in `zsh --no-rcs -c "..."`
+  with Tab pre-bound to `expand-or-complete` and the plugin sourced.
+  Used by tests that need to observe behavior at source time, or
+  that need a clean ZSHZ-internal state.
+
+### Parallel command spawning
+
+- `xargs_P NPROC CMD ARGS...` — drop-in replacement for
+  `xargs -P NPROC -I {} CMD ARGS...`. Reads stdin, substitutes
+  `{}` in each arg with the line, and runs up to NPROC in parallel.
+  Where the system `xargs` supports `-P` (GNU on Linux, modern
+  BSDs), `xargs_P` execs straight into xargs. Where it doesn't
+  (Solaris, AT&T xargs), it falls back to backgrounded `zsh -c`
+  + `wait`.
+
+  **Callers must wrap the invocation in `( ... )` on the right side
+  of the pipe:**
+
+  ```zsh
+  producer | ( xargs_P 4 \
+      env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
+        "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '{}'" )
+  ```
+
+  Two reasons for the call-site parens: (1) zsh does not fork the
+  right side of a pipe when it's a function or block, so the
+  `exec` inside `xargs_P` would otherwise replace the *caller's*
+  shell; the parens force a real subshell for the exec to consume.
+  (2) An equivalent `( ... )` inside the function body triggers
+  SIGBUS on zsh 4.3.11 at higher fork counts — the parens must be
+  at the call site, not in the function.
+
+- `_xargs_supports_P` — probes whether the system `xargs` supports
+  `-P`. Caches the result in `_XARGS_P_OK` (exported, so per-test
+  subshells inherit it). `run.zsh` calls this once at startup so
+  each test subshell skips the re-probe.
+
+## Cross-file helpers
+
+Helpers defined in one test file but used elsewhere. Defined as
+top-level functions so they live in the same global namespace as
+the test functions themselves.
+
+- `_wait_for_add TARGET` (in `test_hooks.zsh`) — poll `$ZSHZ_DATA`
+  up to 2 s for `TARGET` to appear. Necessary because
+  `_zshz_precmd` backgrounds `zshz --add "$PWD"` with `&!` (fork +
+  disown), so `wait` can't see it.
+- `_wait_for_remove TARGET` (in `test_hooks.zsh`) — symmetric: poll
+  for absence.
+- `_zshz_test_zsh_bin` (in `test_emulate.zsh`,
+  `test_strict_options.zsh`, `test_config_errors.zsh`) — print the
+  same zsh binary the runner is using by reading
+  `/proc/$$/exe`, falling back to `${commands[zsh]}`. Lets a
+  child-shell-spawning test exercise the running zsh, including
+  4.3.11 when the runner is invoked under it.
+- `_seed_n_entries N` (in `test_scale.zsh`) — bulk-seed N entries
+  into `$ZSHZ_DATA` in a single redirected block. Calling
+  `zshz_seed` in a loop is much slower at large N because each
+  call opens the datafile; this writes once.
+
+## Conventions for new tests
+
+- **Name with a `test_` prefix.** Anything else is treated as a
+  helper.
+- **Use `$TESTDIR` and `$ZSHZ_DATA` as given.** Don't `unset` them or
+  point them somewhere else; the runner relies on them for cleanup.
+  If a test needs an isolated datafile, create a sub-tempdir under
+  `$TESTDIR`.
+- **No stderr noise.** If a test legitimately invokes commands that
+  emit to stderr, redirect or capture it explicitly. The "no stderr"
+  rule is the suite's primary safety net against silent regressions.
+- **`local` everything.** With `ZSHZ_DEBUG=1` active in tests,
+  `WARN_CREATE_GLOBAL` will flag any accidental global from inside
+  `zshz` itself; tests don't get the same protection automatically,
+  but `local` is still the right discipline.
+- **Use `xargs_P` for concurrent writers.** zsh 4.3.11's `&`/`wait`
+  machinery segfaults under fork load (rc 135), and Solaris `xargs`
+  doesn't support `-P`. The `xargs_P` helper papers over both;
+  the call must be wrapped in `( ... )` on the right side of the
+  pipe (see the helper docs for why). Related patterns:
+  - `_zshz_precmd` uses `&!` (fork + disown) instead of `&`, both
+    to dodge the 4.3.11 segfault and to suppress the "Done"
+    notification at the next prompt.
+  - `test_lock_timeout.zsh` uses `&!` for its lock-holder so no
+    `wait` is needed. Apply the same pattern in any new
+    contention test.
+- **Linux-only path inspection is allowed but should fall back
+  gracefully.** Child-shell tests read `/proc/$$/exe` and fall
+  back to `${commands[zsh]}` when that's missing (Solaris,
+  Cygwin). Tests that rely on `/proc/self/fd/*` or `zsh/zpty`
+  print `skip: ...` and `return 0` when the prerequisite isn't
+  available rather than failing.
+- **Heavy or expensive tests must be gated.** See the
+  `ZSHZ_HEAVY_TESTS=1` gate in `test_scale.zsh`. The default run
+  is meant to be fast (a few seconds).
+- **Pin behavior, don't reproduce it.** Each test should encode an
+  invariant the project commits to keeping. If a test is just
+  exercising code paths without an assertion, the runner has nothing
+  to fail against.
+
+## Commit-message style for test changes
+
+Subject-line only — body optional, only when the change has more
+context than fits in a subject. The subject follows this shape:
+
+```
+tests: <verb> <what the test checks>
+```
+
+Conventions:
+
+- **`tests:` prefix**, lowercase, single colon.
+- **Verb choices**, in rough order of precision: `assert`, `pin`,
+  `confirm`, `cover`, `extend`, `add`. Prefer the verb that
+  describes what the suite *now guarantees* — `assert` and `pin`
+  are usually right for a single test; `cover` and `extend` fit
+  when the change broadens coverage of an existing area; `add`
+  is the fallback for a brand-new file with no clearer single-line
+  framing.
+- **Plain English over jargon.** "opt-in via `ZSHZ_HEAVY_TESTS`"
+  reads better than "gated on `ZSHZ_HEAVY_TESTS`"; "shrinks ranks
+  rather than removing entries" reads better than "scales not
+  deletes." Literal symbol names (`--add`, `&!`, `ZSHZ_LOCK_TIMEOUT`)
+  are fine when they're the most precise referent.
+- **Describe what the test pins, not the activity of adding it.**
+  Bad: `tests: add aging test`. Better: `tests: confirm
+  ZSHZ_MAX_SCORE shrinks ranks rather than removing entries`.
+- **Keep it under ~70 characters** when reasonable; ~80 is fine if
+  the precision is worth it.
+
+Examples from this suite:
+
+```
+tests: assert &! precmd emits no Done line in interactive shell
+tests: assert ZSHZ_LOCK_TIMEOUT bails out and leaves the datafile alone
+tests: assert pre-existing entries survive concurrent --add calls
+tests: pin _zshz_find_common_root behaviour across input orderings
+tests: pin manual --add defenses against $HOME and excluded dirs
+tests: confirm ZSHZ_MAX_SCORE shrinks ranks rather than removing entries
+tests: cover symlink realpath edge cases beyond same-link round-trip
+tests: cover ZSHZ_KEEP_DIRS edge cases beyond simple subtree protection
+tests: extend datafile-robustness coverage
+tests: add a scale-smoke suite, opt-in via ZSHZ_HEAVY_TESTS
+```
+
+## File-by-file index
+
+Each section lists every `test_*` function in the file with one
+sentence describing what it pins. Helpers (`_*` functions) appear
+after the tests when they're file-local; cross-file helpers are
+documented in the section above.
+
+### `test_aging.zsh` — frecency aging at the `ZSHZ_MAX_SCORE` threshold
+
+`_zshz_update_datafile` divides every rank by 0.99 once the total
+crosses `ZSHZ_MAX_SCORE`. The transition is easy to break with off-by-
+one or boolean errors.
+
+- `test_no_aging_below_max_score` — with `ZSHZ_MAX_SCORE=1000`, five
+  consecutive `--add`s leave the rank at exactly 5 (no aging).
+- `test_aging_kicks_in_above_max_score` — with `ZSHZ_MAX_SCORE=5`,
+  seven `--add`s push the running total over the threshold; the rank
+  ends in (6, 7) — short of the literal 7 because the seventh write
+  triggers aging by 0.99.
+- `test_aging_drops_entries_below_rank_1` — entries already below
+  rank 1 (seeded directly) are dropped from the rewritten datafile,
+  not preserved.
+
+### `test_aging_threshold.zsh` — aging is a scale, not a delete
+
+Fills the small gaps between `test_aging.zsh` (single-entry
+threshold transition) and `test_scale.zsh` (aging at scale): aging
+must scale every entry, not just the added one; entries above the
+sub-1 drop threshold survive aging; the time field is preserved.
+
+- `test_aging_scales_all_existing_entries` — three pre-seeded
+  entries (ranks 100/200/300); after one `--add` past the
+  threshold, each is scaled to roughly 0.99 × original. Catches a
+  bug that aged only the `--add`-ed entry's rank.
+- `test_aging_does_not_delete_entries_above_drop_threshold` — a
+  rank-5 and a rank-50 entry both survive aging, ruling out a
+  regression where aging was implemented as deletion.
+- `test_aging_preserves_timestamps` — the aging branch rewrites
+  each entry as `path|0.99*rank|time`; the time field must pass
+  through verbatim.
+
+### `test_basic.zsh` — smoke tests for `--add`, `-x`, `-l`, `-e`
+
+- `test_add_creates_entry_with_rank_1` — first `--add` to a path
+  produces rank 1.
+- `test_add_same_path_twice_increments_rank` — repeated adds bump the
+  rank linearly.
+- `test_add_skips_HOME` — `zshz --add $HOME` is silently rejected.
+- `test_add_skips_excluded_dir` — `ZSHZ_EXCLUDE_DIRS` rejection on
+  the manual `--add` path.
+- `test_add_skips_subtree_of_excluded_dir` — exclusion applies to
+  subdirectories too.
+- `test_add_nonexistent_path_returns_nonzero` — adding a path that
+  doesn't exist on disk fails cleanly.
+- `test_remove_drops_entry` — `zshz -x` removes an exact-match path.
+- `test_remove_R_drops_subtree` — `zshz -xR` removes a directory and
+  all of its descendants.
+- `test_list_shows_added_paths` — `zshz -l` prints each added path
+  on its own line.
+- `test_echo_returns_best_match` — `zshz -e <substr>` prints the
+  matched path without changing directories.
+
+### `test_c_flag.zsh` — `-c` restricts matches to subdirectories of `$PWD`
+
+- `test_c_flag_picks_match_under_pwd` — `zshz -c <substr>` from a
+  parent directory matches a child entry.
+- `test_c_flag_excludes_paths_outside_pwd` — entries outside `$PWD`
+  are filtered out even when their name would otherwise match.
+
+### `test_case.zsh` — `ZSHZ_CASE` controls case-sensitivity
+
+- `test_case_default_falls_back_to_insensitive` — default mode tries
+  case-sensitive first, then case-insensitive when nothing matched.
+- `test_case_default_prefers_sensitive_when_both_available` — given
+  both a case-matching and a case-folded match, default mode picks
+  the case-matching one.
+- `test_case_ignore_always_insensitive` — `ZSHZ_CASE=ignore` matches
+  regardless of case.
+- `test_case_smart_lowercase_query_is_insensitive` — `smart` with
+  an all-lowercase query matches case-insensitively.
+- `test_case_smart_uppercase_query_is_strict` — `smart` with any
+  uppercase character in the query is case-sensitive.
+
+### `test_cd.zsh` — `ZSHZ_CD` substitutes the directory-changer
+
+- `test_jump_uses_default_cd_without_ZSHZ_CD` — without
+  `ZSHZ_CD`, jumps use the builtin `cd`.
+- `test_jump_uses_ZSHZ_CD_when_set` — with `ZSHZ_CD=pushd`, jumps
+  push onto the directory stack.
+- `test_ZSHZ_CD_supports_multi_word_command` — `ZSHZ_CD` may contain
+  multiple words (e.g. wrapped in a logger).
+
+### `test_cleanup.zsh` — stale-entry pruning and `ZSHZ_KEEP_DIRS`
+
+`_zshz_update_datafile` drops entries whose directories no longer
+exist when it rewrites; `ZSHZ_KEEP_DIRS` exempts matching paths.
+
+- `test_stale_entry_pruned_on_next_write` — an entry whose backing
+  directory was removed disappears the next time anything triggers a
+  rewrite.
+- `test_keep_dirs_protects_subtree` — entries under a `KEEP_DIRS`
+  prefix survive even after the directory is gone.
+- `test_keep_dirs_protects_exact_match` — the literal `KEEP_DIRS`
+  path itself survives.
+
+### `test_cli.zsh` — help and invalid-option handling
+
+- `test_help_short_prints_usage` — `zshz -h` prints the usage block.
+- `test_help_long_prints_usage` — `zshz --help` does the same.
+- `test_invalid_option_prints_error_and_usage` — unknown options
+  print an error and the usage.
+- `test_complete_does_not_trigger_add_side_effect` — using `--complete`
+  doesn't end up calling `--add` as a side effect.
+- `test_complete_does_not_trigger_remove_side_effect` — same but for
+  `-x`.
+- `test_complete_help_combo_is_silent` — `--complete --help` together
+  must not surface output through the completion path.
+
+### `test_common_root.zsh` — `_zshz_find_common_root` ordering
+
+`_zshz_find_common_root` is nested inside `zshz()` so we drive it
+through `zshz -e` against datafiles seeded in deliberate orders.
+Pins behavior across array-iteration orderings so a future rewrite
+preserves them.
+
+- `test_common_root_seeded_root_first` — three siblings + their root,
+  root seeded first, root is returned.
+- `test_common_root_seeded_root_middle` — same content, root seeded
+  between the siblings, same outcome.
+- `test_common_root_seeded_root_last` — same content, root seeded
+  last, same outcome.
+- `test_common_root_no_root_entry_picks_highest_ranked` — siblings
+  only (no root entry), the function returns nothing and the highest-
+  ranked sibling wins.
+- `test_common_root_mixed_depth_under_one_root` — depths 1/2/3 under
+  one root, the shortest entry wins regardless of rank.
+- `test_common_root_deep_with_irrelevant_high_rank_neighbour` — a
+  high-rank entry that doesn't match the query must not influence
+  the choice.
+- `test_common_root_single_match_returns_full_path` — degenerate
+  single-match case.
+
+### `test_completion_legacy.zsh` — legacy completion mode
+
+- `test_legacy_complete_returns_matches` — `ZSHZ_COMPLETION=legacy`
+  surfaces alphabetic matches via the completion path.
+- `test_legacy_complete_trailing_slash_matches_directory_end` —
+  `ZSHZ_TRAILING_SLASH` tightens the match boundary at the end of
+  paths.
+
+### `test_concurrency.zsh` — concurrent `--add` correctness
+
+The original concurrency suite. Spawns writers via `xargs_P` (see
+the helper docs above) so the children belong to xargs rather than
+to the test shell, avoiding zsh 4.3.11's `&`/`wait` segfault under
+fork load. On systems without `xargs -P` (Solaris, AT&T xargs),
+`xargs_P` falls back to backgrounded `zsh -c` + `wait`. Tests bump
+`ZSHZ_LOCK_TIMEOUT=30` so honest contention isn't mistaken for a
+regression. Each test gates on `(( ZSHZ[USE_FLOCK] ))` and skips
+when `zsh/system` isn't available — the no-lock fallback can't
+serialize cross-process writers, so the contract isn't testable
+there.
+
+- `test_concurrent_add_no_lost_updates` — 20 writers add the same
+  path in parallel; the final rank is exactly 20 (none lost).
+- `test_lock_fd_does_not_leak_across_repeated_adds` — two synchronous
+  `--add`s in the runner shell, then an external probe with a 1 s
+  timeout that would fail if the runner had leaked an open lock fd
+  (POSIX advisory locks are per-process; a leaked fd would silently
+  hold the lock until shell exit).
+- `test_concurrent_add_two_paths_each_independent` — 30 writers
+  alternating between two paths; each path ends at its expected
+  count, neither's updates are lost to the other's rewrite.
+
+### `test_concurrent_mixed.zsh` — concurrent `--add` and `-x` interleaved
+
+- `test_concurrent_add_and_remove_interleaved` — 23 deliberately
+  mixed ops across four paths via `xargs_P 4`. Doesn't assert exact
+  ranks (order-dependent) but pins (a) every datafile line still
+  matches `/path|rank|time`, (b) no `${datafile}.${RANDOM}` tempfile
+  is left behind, (c) D — added but never removed — is present at
+  the end.
+
+### `test_config_errors.zsh` — config errors `return`, never `exit`
+
+Stronger version of the existing `test_datafile.zsh` checks: those
+asserted that `zshz -l && print SENTINEL` doesn't print SENTINEL,
+which can't tell "zshz returned non-zero" from "the whole shell
+exited." These tests place a sentinel **after** the failing call and
+assert it *does* appear, which only happens if the calling shell
+survived.
+
+- `test_old_zsh_version_check_returns_does_not_exit` — shims
+  `is-at-least` to return false and `autoload` to a no-op;
+  source-with-failed-version prints its error and the calling shell
+  continues.
+- `test_bare_ZSHZ_DATA_returns_does_not_exit` — `ZSHZ_DATA=barefile`
+  fails cleanly, calling shell intact.
+- `test_directory_ZSHZ_DATA_returns_does_not_exit` — `ZSHZ_DATA`
+  pointing at a real directory fails cleanly, calling shell intact.
+
+### `test_datafile.zsh` — datafile robustness
+
+The malformed-line filter
+(`${(M)lines:#/*\|[[:digit:]]##[.,]#[[:digit:]]#\|[[:digit:]]##}`)
+should drop any line that doesn't match the canonical shape, both
+on read and on rewrite.
+
+- `test_malformed_lines_are_filtered` — a hand-crafted datafile with
+  random text, missing-pipe lines, non-numeric ranks, missing-path
+  lines, trailing-junk lines, blank lines, and embedded-newline
+  fragments; `zshz -l` shows only the well-formed entry.
+- `test_add_preserves_valid_entries_amid_malformed_ones` — same
+  shape but verified through `--add`: garbage is dropped on rewrite,
+  valid entries preserved.
+- `test_malformed_datafile_does_not_break_add` — `--add` succeeds
+  even when the prior datafile is entirely garbage.
+- `test_empty_datafile` — zero-byte datafile, `--add` lands rank 1.
+- `test_missing_datafile_is_created` — datafile absent, plugin
+  auto-creates it.
+- `test_list_on_missing_datafile_is_clean_and_empty` — `zshz -l`
+  produces empty output and auto-creates the datafile.
+- `test_search_on_missing_datafile_matches_nothing` — search returns
+  empty without error.
+- `test_remove_on_missing_datafile_does_not_crash` — `zshz -x` on a
+  never-created datafile is a no-op without writing to stderr.
+- `test_list_on_zero_byte_datafile_is_clean_and_empty` — same as
+  list-on-missing but for an existing 0-byte file.
+- `test_whitespace_only_datafile_is_treated_as_empty` — `\n\n\n`
+  content is split into empty array elements by `${(f)...}`,
+  filtered out by the malformed-line filter; `--add` then lands
+  normally.
+- `test_precmd_on_missing_datafile_creates_and_populates` — the
+  fresh-install path: `_zshz_precmd` creates the datafile and adds
+  PWD.
+- `test_ZSHZ_DATA_without_directory_prints_error_and_exits` — bare
+  filename `ZSHZ_DATA` fails with a user-facing error.
+- `test_ZSHZ_DATA_directory_prints_error_and_exits` — `ZSHZ_DATA`
+  pointing at a directory fails with a user-facing error.
+
+### `test_echo.zsh` — `ZSHZ_ECHO`
+
+- `test_echo_off_no_print_on_jump` — without `ZSHZ_ECHO`, jumps are
+  silent.
+- `test_echo_prints_destination_path` — with `ZSHZ_ECHO`, the
+  destination prints after a successful jump.
+- `test_echo_combined_with_tilde` — `ZSHZ_ECHO` + `ZSHZ_TILDE`
+  prints `~`-collapsed paths.
+
+### `test_emulate.zsh` — sourcing under `emulate sh`/`bash`/`ksh`
+
+The plugin uses zsh-only syntax in function bodies; under non-zsh
+emulation those constructs fail to parse. The plugin's gate at the
+top of the file detects non-zsh emulation via
+`[[ -o KSH_ARRAYS || -o SH_WORD_SPLIT ]]` and re-sources itself with
+`emulate zsh -c "source ${(%):-%N}"`. (`${(%):-%N}` is necessary
+because under emulate sh `$0` is the zsh binary, not the script.)
+
+- `test_source_under_emulate_sh` — basic round-trip after
+  `emulate sh`.
+- `test_source_under_emulate_sh_R` — same with `emulate sh -R`
+  (more aggressive option reset).
+- `test_source_under_emulate_bash` — same under `emulate bash`.
+- `test_source_under_emulate_ksh` — same under `emulate ksh`.
+- `test_emulate_gate_does_not_fire_under_pure_zsh` — control:
+  pure zsh path still works, gate doesn't accidentally trigger.
+
+### `test_external_writer.zsh` — read-after-lock under contention
+
+Pins the develop-branch lockfile semantics: an external writer
+running between our read and our `mv` must not lose pre-existing
+entries, and both writers' new adds must land. Deliberately commits
+to develop's design (would fail under `optimistic_concurrency`).
+Spawns writers via `xargs_P`. Both tests skip when
+`ZSHZ[USE_FLOCK]` is 0 (no `zsh/system`).
+
+- `test_external_writer_during_our_add_serializes` — pre-seeded
+  entry at rank 5 survives two concurrent writers each adding a
+  different new path; both new adds land at rank 1.
+- `test_many_concurrent_writers_preserve_seeded_entries` — stronger
+  variant: 10 pre-seeded entries with ranks 1..10, 10 concurrent
+  writers; every seeded rank is intact and every writer's add
+  landed.
+
+### `test_fallback.zsh` — path fallback with no database match
+
+When no entry matches the query, the search code falls through to
+treating the argument as a literal path.
+
+- `test_relative_path_fallback_changes_directory` — relative path
+  fallback works.
+- `test_parent_relative_path_fallback_changes_directory` — `..`-style
+  paths work.
+- `test_absolute_path_fallback_changes_directory` — absolute path
+  fallback works.
+- `test_relative_path_fallback_does_not_apply_with_echo_or_list` —
+  `-e` and `-l` don't trigger the fallback (they're query modes,
+  not jump modes).
+- `test_absolute_path_fallback_does_not_apply_with_echo` — same for
+  absolute paths via `-e`.
+
+### `test_helpers.zsh` — see [Helpers in `test_helpers.zsh`](#helpers-in-test_helpersh)
+
+Not a test file proper; the runner explicitly skips it during the
+"collect tests" pass.
+
+### `test_hooks.zsh` — `precmd` / `chpwd` integration
+
+`_zshz_precmd` backgrounds `zshz --add` via `&!`, so tests use
+`_wait_for_add` (cross-file helper) to wait for the disowned write
+to land before asserting.
+
+- `test_precmd_adds_pwd` — `_zshz_precmd` adds the current `$PWD`.
+- `test_precmd_skips_home_and_excluded_dirs` — `$HOME` and excluded
+  subtrees are short-circuited before reaching the backgrounded write.
+- `test_removed_directory_is_not_readded_until_chpwd` — the
+  `DIRECTORY_REMOVED` guard suppresses re-add until the user `cd`s.
+- `test_precmd_does_not_emit_done_line_in_interactive_shell` —
+  uses `zsh/zpty` to drive a real pty-backed interactive zsh and
+  confirms the disowned write produces no `[N]  + done` notification
+  at the next prompt. The function-call boundary alone is **not**
+  enough to suppress the line when MONITOR is on; `&!` is what
+  actually does it. Gated on `$OSTYPE == linux*`: the fixed sleeps
+  in the sequence assume Linux pty timing, and on Solaris the inner
+  pty isn't ready quickly enough -- the first character of `PS1=`
+  gets eaten and the subsequent `cd` falls into a `>>>` continuation
+  prompt. Also skips when `zsh/zpty` isn't loadable or when
+  `zpty -b` can't acquire a pty. Polls for up to 5 s for the
+  disowned `zshz --add` to land; on failure, dumps the datafile
+  contents and the inner zsh's pty output so a path-canonicalization
+  mismatch is distinguishable from a missed-write timeout.
+- `test_repeated_precmd_under_prompt_spam` — calls `_zshz_precmd`
+  30 times in tight succession and checks `/proc/self/fd/*` for any
+  `.z.lock` fd; resolves entries via zsh's `:A` modifier rather than
+  external `readlink`/`lsof` because `zsystem flock` opens its fd
+  with `FD_CLOEXEC` and a forked inspector would see those fds as
+  already closed.
+
+### `test_keep_dirs.zsh` — `ZSHZ_KEEP_DIRS` edge cases
+
+`test_cleanup.zsh` already covers the simple cases (subtree
+protection, exact-match protection). This file covers the
+boundaries: multiple entries under one root, the `/` root
+shorthand, the prefix-sibling boundary, multiple KEEP_DIRS roots,
+and read-time listing — both `_zshz_update_datafile` (rewrite) and
+`_zshz_find_matches` (read) run the same prune-with-keep-list loop
+and must honour KEEP_DIRS the same way.
+
+- `test_keep_dirs_protects_many_entries_under_one_root` — three
+  seeded entries under a single `KEEP_DIRS` root all survive at
+  their original ranks after the dir is deleted and a rewrite is
+  forced.
+- `test_keep_dirs_root_slash_protects_everything` — the
+  `$dir == '/'` branch: `KEEP_DIRS=( / )` keeps every missing
+  entry. (`test_scale.zsh` relies on this; the contract had no
+  dedicated test before.)
+- `test_keep_dirs_does_not_protect_prefix_sibling` — boundary:
+  `KEEP_DIRS=(/foo)` must not also keep `/foobar` (same shape as
+  the `EXCLUDE_DIRS` boundary in `test_manual_add.zsh`).
+- `test_keep_dirs_with_multiple_entries_each_protects_independently`
+  — three different KEEP_DIRS roots; each protects its own
+  matching entries, and an entry not under any root is still
+  pruned.
+- `test_keep_dirs_affects_read_time_listing` — pins the read-side
+  branch in `_zshz_find_matches`: a missing-dir entry is filtered
+  from `-l` without KEEP_DIRS, surfaces with it.
+
+### `test_legacy_env.zsh` — `_Z_*` legacy variables
+
+The plugin reads `${ZSHZ_*:-${_Z_*}}` so legacy `_Z_*` configs from
+the original `z` continue to work.
+
+- `test__Z_DATA_selects_legacy_datafile` — `_Z_DATA` controls
+  the datafile when `ZSHZ_DATA` is unset.
+- `test__Z_CMD_defines_legacy_alias_name` — `_Z_CMD` controls the
+  alias name when `ZSHZ_CMD` is unset.
+- `test__Z_MAX_SCORE_controls_aging` — `_Z_MAX_SCORE` triggers aging
+  the same way `ZSHZ_MAX_SCORE` does.
+- `test__Z_NO_RESOLVE_SYMLINKS_stores_link_path` — `_Z_NO_RESOLVE_SYMLINKS`
+  controls symlink behavior.
+
+### `test_listing.zsh` — listing output and ordering
+
+- `test_no_args_matches_list_output` — `zshz` with no arguments
+  produces the same output as `zshz -l`.
+- `test_list_rank_and_time_modes_order_entries` — `-l -r` and `-l -t`
+  sort by rank and time respectively.
+- `test_list_prints_common_root_line` — when matches share a common
+  root, `-l` includes a synthesized common-root line.
+
+### `test_lock_timeout.zsh` — `ZSHZ_LOCK_TIMEOUT`
+
+Holder is started with `&!` (fork + disown) rather than `&` because
+`wait` segfaults the test shell on 4.3.11. The holder self-terminates
+after its sleep; `kill $holder` is best-effort cleanup.
+
+- `test_lock_timeout_fires_when_lock_held_externally` — external
+  holder takes the lock; our `--add` with `ZSHZ_LOCK_TIMEOUT=1`
+  returns non-zero in (0.5, 3) s, and the datafile is unchanged
+  (target not added, pre-existing seed rank preserved).
+- `test_lock_timeout_succeeds_when_lock_free` — control: with no
+  contender, the same `--add` succeeds in well under the timeout.
+
+### `test_manual_add.zsh` — manual `zshz --add` defenses
+
+Pins the rejection block in `_zshz_add_or_remove_path` (lines
+210-224) which guards against `zshz --add $HOME` and
+`zshz --add /excluded/path`. Same checks live in `_zshz_precmd` for
+the prompt path; this file covers the user-typed entry point.
+
+- `test_manual_add_of_HOME_is_rejected` — `local HOME=$TESTDIR/home`
+  + `zshz --add "$HOME"` lands no entry.
+- `test_manual_add_of_exact_excluded_dir_is_rejected` — exclude
+  matched against itself.
+- `test_manual_add_of_subdir_of_excluded_dir_is_rejected` — both
+  immediate child and a deeper descendant rejected.
+- `test_manual_add_of_prefix_sibling_of_excluded_is_allowed` — the
+  glob alternation `${exclude}|${exclude}/*` ensures excluding `/foo`
+  doesn't reject `/foobar`.
+- `test_manual_add_of_unrelated_path_is_added` — control: with
+  defenses active, an unrelated path round-trips.
+- `test_manual_add_legacy_Z_EXCLUDE_DIRS_also_rejects` — covers the
+  `${ZSHZ_EXCLUDE_DIRS:-${_Z_EXCLUDE_DIRS}}` legacy fallback.
+- `test_manual_add_of_multiple_excludes_each_rejects` — three
+  exclude entries, each independently rejects.
+
+### `test_matching.zsh` — frecency, `-r`, and `-t` matching
+
+Synthetic ranks/times via `zshz_seed`; paths must exist on disk
+or stale-cleanup would prune them.
+
+- `test_frecency_higher_rank_wins_at_equal_time` — at equal time,
+  rank decides.
+- `test_frecency_recent_wins_at_equal_rank` — at equal rank, recency
+  decides.
+- `test_frecency_high_rank_old_beats_low_rank_recent` — high-rank-
+  but-old beats low-rank-but-recent under default frecency.
+- `test_frecency_recent_low_rank_beats_old_higher_rank` — the reverse
+  threshold: recent + slightly-low rank beats old + slightly-higher
+  rank.
+- `test_rank_match_picks_highest_rank_ignoring_time` — `-r` mode
+  ignores time.
+- `test_time_match_picks_most_recent_ignoring_rank` — `-t` mode
+  ignores rank.
+
+### `test_no_flock.zsh` — fallback when `zsh/system` is unavailable
+
+- `test_add_works_without_flock` — single-process `--add` works with
+  `ZSHZ[USE_FLOCK]=0`.
+- `test_remove_works_without_flock` — `-x` works in the no-flock
+  mode.
+- `test_no_lockfile_created_without_flock` — no `${datafile}.lock`
+  is created in the no-flock mode.
+
+### `test_owner.zsh` — `ZSHZ_OWNER` chown behavior
+
+`zsystem flock` opens the lockfile O_RDWR, so root creating it under
+`sudo -s` and the unprivileged `$ZSHZ_OWNER` user later flocking on
+it would fail with EACCES that is silently swallowed. Both the
+datafile and the lockfile must be chowned together.
+
+- `test_owner_set_chowns_both_datafile_and_lockfile` — mocks
+  `${ZSHZ[CHOWN]}` with a logger; asserts the chown call covers
+  both files.
+- `test_owner_unset_does_not_chown` — without `ZSHZ_OWNER`, no
+  chown happens.
+
+### `test_permissions.zsh` — datafile permission hardening
+
+`~/.z` records every directory the user visits, so it must not be
+readable by other users on a shared host. The plugin lands `.z` at
+mode 0600 by calling `${ZSHZ[CHMOD]} 600` after every file creation
+— the in-process `zf_chmod` builtin on Zsh 5+, and the external
+`chmod` on Zsh 4.3.11. `mv` then atomically replaces `.z` with the
+tempfile and preserves its 0600.
+
+Mode-checking tests probe at runtime whether the underlying
+filesystem honors `chmod` (writing a probe file, chmodding it,
+reading back the mode via `zstat`). This skips MSYS2 — which
+reports `$OSTYPE=cygwin` but ignores chmod on its Windows-backed
+filesystem — while still running on real Cygwin, where POSIX modes
+are honored.
+
+- `test_initial_creation_is_0600` — a fresh `.z` is born at mode
+  0600.
+- `test_add_clamps_preexisting_world_readable_file_to_0600` — a
+  preexisting 0644 `.z` ends up at 0600 after the first `--add`,
+  because the tempfile-rename inherits the tempfile's 0600.
+- `test_remove_keeps_0600` — `-x` rewrites the datafile and
+  preserves mode 0600.
+- `test_repeated_writes_keep_0600` — repeated `--add`s don't drift
+  the mode.
+- `test_initial_creation_chowns_when_ZSHZ_OWNER_set` — under
+  `sudo -s` with `ZSHZ_OWNER=user`, a query-only first call hands
+  `.z` off to the right user immediately rather than leaving a
+  root-owned file the normal-user shell can't read. Mocks
+  `${ZSHZ[CHOWN]}` with a logger.
+- `test_initial_creation_does_not_chown_when_ZSHZ_OWNER_unset` —
+  without `ZSHZ_OWNER`, no chown happens on initial creation.
+
+### `test_resource.zsh` — re-sourcing safety and Tab binding
+
+When the plugin is sourced it captures the current Tab binding into
+`ZSHZ[TAB_BINDING]` so its own widget can chain to it. If sourced
+again it must NOT recapture (else it would record its own widget
+name and recurse infinitely on Tab; see commit 62569dd).
+
+- `test_first_source_captures_existing_tab_binding` — first source
+  records the prior binding.
+- `test_first_source_binds_tab_to_widget` — Tab is bound to the
+  plugin widget after sourcing.
+- `test_resource_does_not_capture_own_widget` — re-source must not
+  recapture its own widget name.
+- `test_resource_keeps_tab_bound_to_widget` — re-source preserves
+  the Tab binding to the widget.
+- `test_first_source_preserves_non_default_tab_binding` — a user's
+  custom Tab binding (e.g. `menu-complete`) is captured verbatim.
+
+### `test_scale.zsh` — large-datafile smoke tests (gated)
+
+Run with `ZSHZ_HEAVY_TESTS=1`. Catches accidental quadratic blowups,
+memory issues, or array-handling bugs that only surface at scale.
+Uses `ZSHZ_KEEP_DIRS=( / )` so the missing-directory prune doesn't
+require `mkdir`-ing 5000 stub directories.
+
+- `test_large_datafile_list_completes` — `zshz -l` against 5000
+  seeded entries returns at least N − 100 lines.
+- `test_large_datafile_add_preserves_entries` — with aging disabled
+  via a high `ZSHZ_MAX_SCORE`, an `--add` to a new path lands
+  cleanly and the first/last seeded entries survive verbatim.
+- `test_large_datafile_search_returns_a_match` — search through
+  5000 entries finds `dir_4242`.
+- `test_large_datafile_aging_triggers_at_scale` — ranks 1..5000 sum
+  far above the default `MAX_SCORE`; one more `--add` ages all 5000
+  entries by 0.99, sampled `dir_1` lands in (1.9, 2), `dir_5000`
+  in (4940, 5000).
+
+### `test_special_chars.zsh` — paths with shell-special characters
+
+Round-trip through `--add`, `zshz -e <substr>`, `zshz -l`, and
+`zshz -x` for each kind of special character. Exercises `${(q)2}`
+quoting in `_zshz_update_datafile` and the escape list in
+`_zshz_find_matches`.
+
+- `test_path_with_spaces_round_trip` — paths with literal spaces.
+- `test_path_with_brackets_round_trip` — `[`, `]`.
+- `test_path_with_star_round_trip` — `*` in a path.
+- `test_path_with_question_mark_round_trip` — `?` in a path.
+- `test_path_with_backtick_round_trip` — backtick in a path.
+- `test_path_with_single_quote_round_trip` — single quote in a path.
+- `test_path_with_dollar_sign_round_trip` — `$` in a path. Originally
+  failed because `_zshz_find_matches` accessed
+  `(( matches[$escaped_path_field] ))` in math context (which re-
+  expands `$` in the subscript); the plugin now escapes `$` in the
+  same place it escapes \, ` , ( , ) , [ , ].
+- `test_path_with_mixed_special_chars_round_trip` — all seven specials
+  in one path; pins the quoting machinery rather than the
+  search-side handling of metas in queries (the search query uses
+  `mixed`, an ASCII non-meta substring).
+
+### `test_strict_options.zsh` — sourcing under `NO_UNSET`/`WARN_CREATE_GLOBAL`/`NO_NOMATCH`
+
+- `test_source_with_NO_UNSET` — sources under `NO_UNSET`, runs
+  `--add` + `_zshz_precmd` + `-l`. No "parameter not set" warnings.
+- `test_source_with_WARN_CREATE_GLOBAL` — same under
+  `WARN_CREATE_GLOBAL`. The plugin's careful `local` discipline
+  must keep stderr clean.
+- `test_source_with_NO_NOMATCH` — same under `NO_NOMATCH`.
+- `test_source_with_combined_strict_options` — all three at once,
+  the realistic strict-rc scenario.
+
+### `test_symlink_realpath.zsh` — realpath edge cases for symlinks
+
+Covers cases `test_symlinks.zsh` doesn't reach: two distinct
+symlinks resolving to the same target, target/symlink asymmetry,
+chained symlinks, `..` traversal collapsing, and the negative case
+under `ZSHZ_NO_RESOLVE_SYMLINKS=1` where two symlinks to the same
+target are *not* the same database key.
+
+- `test_two_symlinks_to_same_target_share_a_db_entry` — under
+  default mode, `--add` via `link1/inner` and `-x` via
+  `link2/inner` round-trip via the canonical resolved target.
+- `test_add_via_symlink_remove_via_target` — adding through a
+  symlink and removing via the underlying target works.
+- `test_add_via_target_remove_via_symlink` — the inverse: adding
+  via the target and removing via a symlink also works.
+- `test_chained_symlinks_resolve_to_final_target` — `link_outer ->
+  link_inner -> target`; `:A` walks the whole chain.
+- `test_dotdot_traversal_is_canonicalised` — `--add foo/../foo/bar`
+  lands as `foo/bar`; the literal traversal form is not preserved.
+- `test_no_resolve_keeps_two_symlinks_distinct` — under
+  `ZSHZ_NO_RESOLVE_SYMLINKS=1`, removing via `link2` does *not*
+  remove the entry added via `link1`; the user has to remove via
+  the same path that added it.
+
+### `test_symlinks.zsh` — symlink add/remove parity
+
+`--add` and `-x` must treat the same path the same way regardless of
+symlink resolution mode.
+
+- `test_symlink_add_remove_parity_default` — default mode (resolve
+  symlinks): adding through the link removes through the link.
+- `test_symlink_add_remove_parity_no_resolve` — same with
+  `ZSHZ_NO_RESOLVE_SYMLINKS=1`.
+- `test_symlink_add_default_stores_resolved_target` — the stored
+  path is the symlink target under default mode.
+- `test_symlink_add_no_resolve_does_not_store_target` — the stored
+  path is the symlink itself when resolution is off.
+
+### `test_tempfile_cleanup.zsh` — no leftover `${datafile}.NNNNN`
+
+Pins single-process tempfile-cleanup paths in
+`_zshz_add_or_remove_path`. Each rewrite uses
+`${datafile}.${RANDOM}` and atomically `mv`s it over the datafile;
+every failure path must `rm -f` the tempfile before returning.
+`test_concurrent_mixed.zsh` already pins the same invariant under
+concurrent ops; this file pins the synchronous failure paths.
+
+- `test_no_tempfile_after_normal_add` — sanity: a single successful
+  `--add` leaves no `${datafile}.<N>` behind.
+- `test_no_tempfile_after_many_sequential_adds` — 20 consecutive
+  adds; catches the case where each leaks one (accumulation), not
+  just the first.
+- `test_no_tempfile_after_mv_failure` — `ZSHZ[MV]=false` to make
+  the rename always fail; the post-mv cleanup branch must run, the
+  datafile is unchanged, the new entry didn't land. Helper
+  `_no_tempfile_in DIR` (defined in the file) does the glob check.
+- `test_no_tempfile_after_lock_timeout` — lock held externally,
+  `ZSHZ_LOCK_TIMEOUT=1`. The timeout path returns before opening
+  the tempfile, so there's nothing to clean up; a future refactor
+  that moved tempfile creation before `flock` would surface as a
+  leak here.
+
+Two failure scenarios from the LIST.md spec are intentionally
+*not* covered, with reasons spelled out in the file's header:
+
+- *Read-only parent dir mid-write*: once the dir is read-only,
+  the plugin's own `mkdir -p`/`touch` to ensure the datafile
+  exists also fails and writes to stderr ahead of where we want
+  to test. The mocked-MV test exercises the same cleanup branch
+  more cleanly.
+- *Kill the writer mid-write*: SIGKILL admits no shell-level
+  cleanup; the plugin doesn't trap signals so SIGTERM also
+  leaks. That's a "should we add a trap?" item, not a contract
+  we currently enforce.
+
+### `test_tilde.zsh` — `ZSHZ_TILDE`
+
+- `test_tilde_replaces_home_in_list_output` — `-l` shows `~/foo`
+  instead of `/home/user/foo` when `ZSHZ_TILDE` is set.
+- `test_tilde_off_shows_full_home_path` — with `ZSHZ_TILDE` unset,
+  the full path appears.
+- `test_tilde_in_echo_output` — `-e` likewise honors `ZSHZ_TILDE`.
+
+### `test_uncommon.zsh` — `ZSHZ_UNCOMMON`
+
+`ZSHZ_UNCOMMON=1` shrinks the chosen destination to the shortest
+ancestor that still contains the same number of search-pattern
+matches as the original entry.
+
+- `test_uncommon_shrinks_to_keep_pattern_count` — `/foo/bar/foo/bar`
+  with query `foo` shrinks to `/foo/bar/foo`.
+- `test_default_with_single_match_returns_full_path` — without
+  `UNCOMMON`, a single match returns its full path.
+- `test_default_returns_common_root_when_one_exists` — without
+  `UNCOMMON`, when matches share a common root that's in the
+  database, the root is returned (as a single line).
+
+### `test_unicode.zsh` — non-ASCII paths
+
+- `test_path_with_latin_extended_round_trip` — `café/résumé` round-
+  trips, search by `café`.
+- `test_path_with_cjk_round_trip` — `日本語/プロジェクト` round-trips,
+  search by `日本語`.
+- `test_path_with_cyrillic_round_trip` — `привет/мир` round-trips,
+  search by `привет`.
+- `test_ascii_substring_finds_path_with_unicode` — ASCII substring
+  search across UTF-8 byte boundaries (`proj-café-2026/notes`
+  searched by `proj`).
+
+### `test_unload.zsh` — plugin unload / reload contract
+
+Per the Zsh Plugin Standard, `zsh-z_plugin_unload` must drop functions
+and the widget, restore the prior Tab binding, remove precmd/chpwd
+hooks, and unset `ZSHZ`. Re-sourcing should bring everything back.
+
+- `test_unload_removes_zshz_function` — `zshz` function gone after
+  unload.
+- `test_unload_unsets_ZSHZ_global` — `ZSHZ` associative array gone
+  after unload.
+- `test_unload_removes_widget` — `_zshz_zle_completion_widget` gone.
+- `test_unload_restores_prior_tab_binding` — Tab is re-bound to the
+  binding the plugin captured at source time.
+- `test_unload_leaves_user_rebound_tab_alone` — if the user re-bound
+  Tab themselves *between* source and unload, unload doesn't
+  clobber that.
+- `test_unload_removes_hooks` — `_zshz_precmd` and `_zshz_chpwd` are
+  removed from `precmd_functions` / `chpwd_functions`.
+- `test_unload_then_reload_restores_function_and_widget` — sourcing
+  again after unload restores the plugin to a clean state.
+- `test_reload_after_unload_captures_current_tab_binding` — re-source
+  captures whatever Tab is bound to *now* (not the original
+  `expand-or-complete`).
+
+### `test_widget.zsh` — ZLE completion widget logic
+
+`_zshz_zle_completion_widget` collapses multiple search terms into
+one `*`-joined token before delegating to the saved Tab binding. We
+can't drive a real ZLE session non-interactively, so each test stubs
+`zle` to a no-op and inspects `LBUFFER` after the call.
+
+- `test_widget_joins_multiple_search_terms_with_asterisk` —
+  `z us lo bi` becomes `z us*lo*bi`.
+- `test_widget_preserves_flags_before_search_terms` — `z -e foo bar`
+  becomes `z -e foo*bar` (flags stay separate from joined terms).
+- `test_widget_passes_through_single_term` — single-term queries
+  are unchanged.
+- `test_widget_does_not_retrigger_on_completed_absolute_path` — a
+  buffer ending in a trailing space after an absolute path bails
+  out so a second Tab doesn't insert a duplicate.
+- `test_widget_recognizes_long_flags` — `--add`, `--complete`,
+  `--help` are recognized as flags.
+- `test_widget_uses_custom_ZSHZ_CMD` — the widget keys off
+  `ZSHZ_CMD` (or `_Z_CMD`), not a hardcoded `z`.
+- `test_widget_passes_through_single_path_after_long_flag` — a
+  single argument after a long flag isn't joined to anything.
+- `test_widget_double_dash_terminates_option_parsing` — `--`
+  terminates option parsing; subsequent tokens are positional.
+
+## Auxiliary scripts
+
+### `tests/stress.sh`
+
+A standalone bash-driven cross-process stress test for concurrent
+`--add`. Spawns N writers (default 100) at parallelism P (default 8),
+each in its own `zsh -c` source-and-add cycle, and asserts the final
+rank equals N. Sets `ZSHZ_LOCK_TIMEOUT=30` so honest contention
+isn't dropped on timeout. Uses `xargs -P` where available; falls back
+to bash background jobs throttled to `$PARALLEL` via batch-wait on
+systems without it (Solaris, AT&T xargs).
+
+```sh
+tests/stress.sh                     # 100 writers, 8-way parallel
+N=200 PARALLEL=8 tests/stress.sh    # 200 writers
+N=200 tests/stress.sh ~/zsh/4.3.11/bin/zsh   # against an alternate zsh
+```
+
+Not part of the regular run; intended for one-off verification of
+lock correctness under heavy load and on multiple zsh versions.
+
+### `.github/workflows/test.yml`
+
+Minimal CI matrix: `ubuntu-latest` and `macos-latest`. Each runner
+installs zsh (Linux only — macOS ships zsh by default), syntax-
+checks both `zsh-z.plugin.zsh` and `_zshz`, then runs
+`zsh tests/run.zsh`. The default suite (no `ZSHZ_HEAVY_TESTS`) is
+expected to complete in well under a minute.
+
+<!-- vim: ft=markdown:tw=72: -->

--- a/tests/run.zsh
+++ b/tests/run.zsh
@@ -82,3 +82,4 @@ done
 print
 print "Results: $passed passed, $failed failed of $total"
 (( failed == 0 ))
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/run.zsh
+++ b/tests/run.zsh
@@ -36,6 +36,18 @@ for _fn in ${(k)functions}; do
 done
 _test_fns=( ${(o)_test_fns} )
 
+# If names were passed on the command line, run only those tests. Each arg is
+# matched as a glob against test function names, so prefixes work too:
+#   zsh tests/run.zsh test_concurrent_add_no_lost_updates
+#   zsh tests/run.zsh 'test_concurrent_*'
+if (( $# )); then
+  _test_fns=( ${(M)_test_fns:#${~^@}} )
+  if (( ! ${#_test_fns} )); then
+    print -u 2 "No tests matched: $*"
+    exit 2
+  fi
+fi
+
 typeset -gi total=0 passed=0 failed=0
 typeset -ga failures
 

--- a/tests/run.zsh
+++ b/tests/run.zsh
@@ -6,15 +6,22 @@
 # produced by a test causes it to fail (so WARN_CREATE_GLOBAL warnings and
 # unintended errors both surface).
 
-setopt PIPE_FAIL EXTENDED_GLOB
+setopt EXTENDED_GLOB
+# Zsh 4.3.11 does not have PIPE_FAIL.
+(( ${+options[pipefail]} )) && setopt PIPE_FAIL
 
-PLUGIN_DIR=${0:A:h:h}
-TESTS_DIR=${0:A:h}
+TESTS_DIR=${0:h}
+[[ $TESTS_DIR == $0 ]] && TESTS_DIR=.
+TESTS_DIR=$(builtin cd "$TESTS_DIR" && builtin pwd -P) || exit 2
+PLUGIN_DIR=$(builtin cd "$TESTS_DIR/.." && builtin pwd -P) || exit 2
 
 source "$PLUGIN_DIR/zsh-z.plugin.zsh"
 source "$TESTS_DIR/test_helpers.zsh"
 
-typeset -ga _test_files=( "$TESTS_DIR"/test_*.zsh )
+typeset -ga _test_files
+while IFS= read -r _f; do
+  _test_files+=( "$_f" )
+done < <(find "$TESTS_DIR" -maxdepth 1 -type f -name 'test_*.zsh' | LC_ALL=C sort)
 typeset -ga _test_fns
 
 # Collect test functions in source order

--- a/tests/run.zsh
+++ b/tests/run.zsh
@@ -24,7 +24,8 @@ while IFS= read -r _f; do
 done < <(find "$TESTS_DIR" -maxdepth 1 -type f -name 'test_*.zsh' | LC_ALL=C sort)
 typeset -ga _test_fns
 
-# Collect test functions in source order
+# Collect test functions from the sourced files, then sort by name so the
+# execution order is stable.
 for _f in $_test_files; do
   [[ ${_f:t} == test_helpers.zsh ]] && continue
   source "$_f"

--- a/tests/run.zsh
+++ b/tests/run.zsh
@@ -1,0 +1,76 @@
+#!/usr/bin/env zsh
+# Test runner for Zsh-z. Exits non-zero if any test fails.
+#
+# A test is a function named test_* defined in any tests/test_*.zsh file.
+# Each test runs against a fresh ZSHZ_DATA in a tempdir; any non-empty stderr
+# produced by a test causes it to fail (so WARN_CREATE_GLOBAL warnings and
+# unintended errors both surface).
+
+setopt PIPE_FAIL EXTENDED_GLOB
+
+PLUGIN_DIR=${0:A:h:h}
+TESTS_DIR=${0:A:h}
+
+source "$PLUGIN_DIR/zsh-z.plugin.zsh"
+source "$TESTS_DIR/test_helpers.zsh"
+
+typeset -ga _test_files=( "$TESTS_DIR"/test_*.zsh )
+typeset -ga _test_fns
+
+# Collect test functions in source order
+for _f in $_test_files; do
+  [[ ${_f:t} == test_helpers.zsh ]] && continue
+  source "$_f"
+done
+
+for _fn in ${(k)functions}; do
+  [[ $_fn == test_* ]] && _test_fns+=( $_fn )
+done
+_test_fns=( ${(o)_test_fns} )
+
+typeset -gi total=0 passed=0 failed=0
+typeset -ga failures
+
+for fn in $_test_fns; do
+  (( total++ ))
+
+  TESTDIR=$(mktemp -d -t zshz-test.XXXXXX) || { print -u 2 "mktemp failed"; exit 2; }
+  export ZSHZ_DATA="$TESTDIR/.z"
+  STDERR_LOG="$TESTDIR/stderr.log"
+  STDOUT_LOG="$TESTDIR/stdout.log"
+
+  # Run the test in a subshell so cd / env / option changes don't leak.
+  ( ZSHZ_DEBUG=1; cd "$TESTDIR"; "$fn" ) > "$STDOUT_LOG" 2> "$STDERR_LOG"
+  rc=$?
+
+  reason=""
+  (( rc != 0 )) && reason="rc=$rc"
+  if [[ -s $STDERR_LOG ]]; then
+    [[ -n $reason ]] && reason="$reason; "
+    reason="${reason}stderr"
+  fi
+
+  if [[ -z $reason ]]; then
+    (( passed++ ))
+    print "PASS  $fn"
+  else
+    (( failed++ ))
+    failures+=( "$fn" )
+    print "FAIL  $fn ($reason)"
+    if [[ -s $STDOUT_LOG ]]; then
+      print "  --- stdout ---"
+      sed 's/^/  /' "$STDOUT_LOG"
+    fi
+    if [[ -s $STDERR_LOG ]]; then
+      print "  --- stderr ---"
+      sed 's/^/  /' "$STDERR_LOG"
+    fi
+  fi
+
+  rm -rf "$TESTDIR"
+  unset TESTDIR ZSHZ_DATA STDERR_LOG STDOUT_LOG
+done
+
+print
+print "Results: $passed passed, $failed failed of $total"
+(( failed == 0 ))

--- a/tests/run.zsh
+++ b/tests/run.zsh
@@ -19,9 +19,7 @@ source "$PLUGIN_DIR/zsh-z.plugin.zsh"
 source "$TESTS_DIR/test_helpers.zsh"
 
 typeset -ga _test_files
-while IFS= read -r _f; do
-  _test_files+=( "$_f" )
-done < <(find "$TESTS_DIR" -maxdepth 1 -type f -name 'test_*.zsh' | LC_ALL=C sort)
+_test_files=( "$TESTS_DIR"/test_*.zsh(.N) )
 typeset -ga _test_fns
 
 # Collect test functions from the sourced files, then sort by name so the

--- a/tests/run.zsh
+++ b/tests/run.zsh
@@ -56,7 +56,12 @@ typeset -ga failures
 for fn in $_test_fns; do
   (( total++ ))
 
-  TESTDIR=$(mktemp -d -t zshz-test.XXXXXX) || { print -u 2 "mktemp failed"; exit 2; }
+  # `mktemp -d -t prefix' is non-portable: GNU substitutes the X's in
+  # `prefix' in place, but Solaris/BSD mktemp treats `prefix' as a
+  # literal and appends its own suffix, producing names like
+  # `/tmp/zshz-test..XXXX' -- the extra dot breaks tests that assert no
+  # `..' appears in stored paths. The direct-template form is portable.
+  TESTDIR=$(mktemp -d "${TMPDIR:-/tmp}/zshz-test.XXXXXX") || { print -u 2 "mktemp failed"; exit 2; }
   export ZSHZ_DATA="$TESTDIR/.z"
   STDERR_LOG="$TESTDIR/stderr.log"
   STDOUT_LOG="$TESTDIR/stdout.log"

--- a/tests/run.zsh
+++ b/tests/run.zsh
@@ -62,6 +62,11 @@ for fn in $_test_fns; do
   # `/tmp/zshz-test..XXXX' -- the extra dot breaks tests that assert no
   # `..' appears in stored paths. The direct-template form is portable.
   TESTDIR=$(mktemp -d "${TMPDIR:-/tmp}/zshz-test.XXXXXX") || { print -u 2 "mktemp failed"; exit 2; }
+  # Canonicalize: on macOS $TMPDIR lives under /var (a symlink to /private/var)
+  # and carries a trailing slash, so the raw path differs from the symlink- and
+  # slash-normalized one Zsh-z stores. Resolve it once here, the same way
+  # TESTS_DIR/PLUGIN_DIR are resolved above, so tests built from $TESTDIR match.
+  TESTDIR=$(builtin cd "$TESTDIR" && builtin pwd -P) || { print -u 2 "cd failed"; exit 2; }
   export ZSHZ_DATA="$TESTDIR/.z"
   STDERR_LOG="$TESTDIR/stderr.log"
   STDOUT_LOG="$TESTDIR/stdout.log"

--- a/tests/run.zsh
+++ b/tests/run.zsh
@@ -18,6 +18,10 @@ PLUGIN_DIR=$(builtin cd "$TESTS_DIR/.." && builtin pwd -P) || exit 2
 source "$PLUGIN_DIR/zsh-z.plugin.zsh"
 source "$TESTS_DIR/test_helpers.zsh"
 
+# Probe once and export the result so per-test subshells skip the
+# re-probe. The fork the probe avoids matters on zsh 4.3.11.
+_xargs_supports_P >/dev/null
+
 typeset -ga _test_files
 _test_files=( "$TESTS_DIR"/test_*.zsh(.N) )
 typeset -ga _test_fns

--- a/tests/stress.sh
+++ b/tests/stress.sh
@@ -14,12 +14,17 @@ TESTDIR=$(mktemp -d -t zshz-stress.XXXXXX)
 trap 'rm -rf "$TESTDIR"' EXIT
 
 export ZSHZ_DATA="$TESTDIR/.z"
+# Default flock timeout (1s) is meant to keep a stuck holder from freezing
+# the prompt; under heavy stress, give writers plenty of time to acquire so
+# we measure real lock-correctness, not the timeout drop-rate.
+export ZSHZ_LOCK_TIMEOUT=${ZSHZ_LOCK_TIMEOUT:-30}
 TARGET="$TESTDIR/target"
 mkdir -p "$TARGET"
 
-echo "zsh:      $("$ZSH_BIN" --version)"
-echo "writers:  $N"
-echo "parallel: $PARALLEL"
+echo "zsh:           $("$ZSH_BIN" --version)"
+echo "writers:       $N"
+echo "parallel:      $PARALLEL"
+echo "lock timeout:  ${ZSHZ_LOCK_TIMEOUT}s"
 
 seq 1 "$N" | xargs -P "$PARALLEL" -I{} \
   "$ZSH_BIN" -c "source '$PLUGIN'; zshz --add '$TARGET'"

--- a/tests/stress.sh
+++ b/tests/stress.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Stress Zsh-z concurrent --add without relying on the harness shell's
+# fork-and-wait, which segfaults on zsh 4.3.11.
+#
+# Usage:  stress.sh [zsh-binary]   (default: zsh)
+#         N=200 PARALLEL=8 stress.sh ~/bin/zsh-4.3.11
+set -eu
+ZSH_BIN=${1:-zsh}
+N=${N:-100}
+PARALLEL=${PARALLEL:-8}
+
+PLUGIN=$(realpath zsh-z.plugin.zsh)
+TESTDIR=$(mktemp -d -t zshz-stress.XXXXXX)
+trap 'rm -rf "$TESTDIR"' EXIT
+
+export ZSHZ_DATA="$TESTDIR/.z"
+TARGET="$TESTDIR/target"
+mkdir -p "$TARGET"
+
+echo "zsh:      $("$ZSH_BIN" --version)"
+echo "writers:  $N"
+echo "parallel: $PARALLEL"
+
+seq 1 "$N" | xargs -n1 -P "$PARALLEL" -I{} \
+  "$ZSH_BIN" -c "source '$PLUGIN'; zshz --add '$TARGET'"
+
+rank=$(awk -F'|' -v p="$TARGET" '$1==p { print $2 }' "$ZSHZ_DATA")
+echo "expected rank: $N"
+echo "actual rank:   ${rank:-0}"
+[[ "$rank" == "$N" ]] && echo "PASS" || { echo "FAIL: lost $((N - ${rank:-0})) updates"; exit 1; }  

--- a/tests/stress.sh
+++ b/tests/stress.sh
@@ -21,7 +21,7 @@ echo "zsh:      $("$ZSH_BIN" --version)"
 echo "writers:  $N"
 echo "parallel: $PARALLEL"
 
-seq 1 "$N" | xargs -n1 -P "$PARALLEL" -I{} \
+seq 1 "$N" | xargs -P "$PARALLEL" -I{} \
   "$ZSH_BIN" -c "source '$PLUGIN'; zshz --add '$TARGET'"
 
 rank=$(awk -F'|' -v p="$TARGET" '$1==p { print $2 }' "$ZSHZ_DATA")

--- a/tests/stress.sh
+++ b/tests/stress.sh
@@ -26,8 +26,24 @@ echo "writers:       $N"
 echo "parallel:      $PARALLEL"
 echo "lock timeout:  ${ZSHZ_LOCK_TIMEOUT}s"
 
-seq 1 "$N" | xargs -P "$PARALLEL" -I{} \
-  "$ZSH_BIN" -c "source '$PLUGIN'; zshz --add '$TARGET'"
+# Solaris (and other AT&T-derived) xargs don't support -P. Use it where
+# available; otherwise fall back to bash's own job control, throttled to
+# $PARALLEL by waiting on each batch.
+if : | xargs -P 1 -I {} true 2>/dev/null; then
+  seq 1 "$N" | xargs -P "$PARALLEL" -I{} \
+    "$ZSH_BIN" -c "source '$PLUGIN'; zshz --add '$TARGET'"
+else
+  pids=()
+  for ((i=1; i<=N; i++)); do
+    "$ZSH_BIN" -c "source '$PLUGIN'; zshz --add '$TARGET'" &
+    pids+=( $! )
+    if (( ${#pids[@]} >= PARALLEL )); then
+      wait "${pids[@]}"
+      pids=()
+    fi
+  done
+  (( ${#pids[@]} )) && wait "${pids[@]}"
+fi
 
 rank=$(awk -F'|' -v p="$TARGET" '$1==p { print $2 }' "$ZSHZ_DATA")
 echo "expected rank: $N"

--- a/tests/stress.sh
+++ b/tests/stress.sh
@@ -2,6 +2,14 @@
 # Stress Zsh-z concurrent --add without relying on the harness shell's
 # fork-and-wait, which segfaults on zsh 4.3.11.
 #
+# This is the heavy, tunable, manual counterpart to the fast regression
+# gate `test_concurrent_add_no_lost_updates' in tests/test_concurrency.zsh:
+# both assert that N concurrent `--add's of one path yield rank N (no lost
+# updates), but that test is capped small (n=20) for CI while this one
+# cranks N/PARALLEL high and can target an arbitrary zsh binary. Keep the
+# shared invariant (datafile format, rank==N, ZSHZ_LOCK_TIMEOUT) in sync
+# between the two. Not part of `run.zsh'; invoke by hand.
+#
 # Usage:  stress.sh [zsh-binary]   (default: zsh)
 #         N=200 PARALLEL=8 stress.sh ~/bin/zsh-4.3.11
 set -eu

--- a/tests/test_aging.zsh
+++ b/tests/test_aging.zsh
@@ -39,3 +39,4 @@ test_aging_drops_entries_below_rank_1() {
   zshz --add "$TESTDIR/keep"
   assert_eq "" "$(zshz_rank_of "$TESTDIR/decayed")" "entry with rank<1 should be dropped on write"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_aging.zsh
+++ b/tests/test_aging.zsh
@@ -1,8 +1,8 @@
 # Aging behavior at the ZSHZ_MAX_SCORE threshold.
 #
-# When the sum of stored ranks exceeds ZSHZ_MAX_SCORE, the next write multiplies
-# every rank by 0.99 (zsh-z.plugin.zsh:399-403) -- a state transition that's
-# easy to break with off-by-one or boolean errors.
+# `_zshz_update_datafile` ages the database once the total stored rank exceeds
+# `ZSHZ_MAX_SCORE`, multiplying each stored rank by 0.99. That threshold
+# transition is easy to break with off-by-one or boolean errors.
 
 test_no_aging_below_max_score() {
   mkdir -p "$TESTDIR/x"
@@ -30,9 +30,9 @@ test_aging_kicks_in_above_max_score() {
 }
 
 test_aging_drops_entries_below_rank_1() {
-  # When aging would push a rank below 1, the entry is dropped on the next
-  # write (line 388: `(( rank_field < 1 )) && continue`). Seed an entry with
-  # rank 0.5 directly and trigger a write.
+  # Entries whose stored rank is already below 1 are skipped when
+  # `_zshz_update_datafile` rewrites the datafile. Seed an entry with rank 0.5
+  # directly and trigger a write.
   mkdir -p "$TESTDIR/keep" "$TESTDIR/decayed"
   zshz_seed "$TESTDIR/keep" 10
   zshz_seed "$TESTDIR/decayed" 0.5

--- a/tests/test_aging.zsh
+++ b/tests/test_aging.zsh
@@ -33,11 +33,8 @@ test_aging_drops_entries_below_rank_1() {
   # write (line 388: `(( rank_field < 1 )) && continue`). Seed an entry with
   # rank 0.5 directly and trigger a write.
   mkdir -p "$TESTDIR/keep" "$TESTDIR/decayed"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/keep|10|$now" \
-    "$TESTDIR/decayed|0.5|$now" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/keep" 10
+  zshz_seed "$TESTDIR/decayed" 0.5
   zshz --add "$TESTDIR/keep"
   assert_eq "" "$(zshz_rank_of "$TESTDIR/decayed")" "entry with rank<1 should be dropped on write"
 }

--- a/tests/test_aging.zsh
+++ b/tests/test_aging.zsh
@@ -22,7 +22,8 @@ test_aging_kicks_in_above_max_score() {
   local i
   for i in {1..7}; do zshz --add "$TESTDIR/x"; done
 
-  local rank=$(zshz_rank_of "$TESTDIR/x")
+  local rank
+  rank=$(zshz_rank_of "$TESTDIR/x")
   [[ -n $rank ]] || fail "rank should be present"
   (( rank < 7 )) || fail "rank should be < 7 after aging, was $rank"
   (( rank > 6 )) || fail "rank should be > 6 after aging, was $rank"

--- a/tests/test_aging.zsh
+++ b/tests/test_aging.zsh
@@ -1,0 +1,43 @@
+# Aging behavior at the ZSHZ_MAX_SCORE threshold.
+#
+# When the sum of stored ranks exceeds ZSHZ_MAX_SCORE, the next write multiplies
+# every rank by 0.99 (zsh-z.plugin.zsh:399-403) -- a state transition that's
+# easy to break with off-by-one or boolean errors.
+
+test_no_aging_below_max_score() {
+  mkdir -p "$TESTDIR/x"
+  ZSHZ_MAX_SCORE=1000
+  local i
+  for i in {1..5}; do zshz --add "$TESTDIR/x"; done
+  assert_eq "5" "$(zshz_rank_of "$TESTDIR/x")" "rank should be exact integer below threshold"
+}
+
+test_aging_kicks_in_above_max_score() {
+  mkdir -p "$TESTDIR/x"
+  ZSHZ_MAX_SCORE=5
+  # 7 sequential adds with MAX_SCORE=5:
+  #   adds 1..6: count of pre-existing ranks (0..5) never exceeds 5, stored
+  #              rank ends at 6
+  #   add 7: count=6 > 5 triggers aging, stored rank = 0.99 * 7 = 6.93
+  local i
+  for i in {1..7}; do zshz --add "$TESTDIR/x"; done
+
+  local rank=$(zshz_rank_of "$TESTDIR/x")
+  [[ -n $rank ]] || fail "rank should be present"
+  (( rank < 7 )) || fail "rank should be < 7 after aging, was $rank"
+  (( rank > 6 )) || fail "rank should be > 6 after aging, was $rank"
+}
+
+test_aging_drops_entries_below_rank_1() {
+  # When aging would push a rank below 1, the entry is dropped on the next
+  # write (line 388: `(( rank_field < 1 )) && continue`). Seed an entry with
+  # rank 0.5 directly and trigger a write.
+  mkdir -p "$TESTDIR/keep" "$TESTDIR/decayed"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/keep|10|$now" \
+    "$TESTDIR/decayed|0.5|$now" \
+    > "$ZSHZ_DATA"
+  zshz --add "$TESTDIR/keep"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/decayed")" "entry with rank<1 should be dropped on write"
+}

--- a/tests/test_aging_threshold.zsh
+++ b/tests/test_aging_threshold.zsh
@@ -1,0 +1,78 @@
+# Aging behaviour at the `ZSHZ_MAX_SCORE` threshold, beyond what
+# `test_aging.zsh` and `test_scale.zsh` already cover.
+#
+# `test_aging.zsh` pins the threshold transition (no aging below,
+# aging above) by adding repeatedly to one path. `test_scale.zsh`
+# exercises aging across thousands of entries. This file fills the
+# small-but-explicit gaps:
+#
+#   - Aging scales *every* entry, not just the one being added.
+#     A bug that aged only the added entry's rank would still pass
+#     `test_aging_kicks_in_above_max_score'.
+#   - Aging is a *scale-down*, not a delete: entries with rank > 1
+#     survive aging at their scaled rank (they aren't accidentally
+#     filtered out by the sub-1 drop check).
+#   - The time field is preserved through aging.
+
+test_aging_scales_all_existing_entries() {
+  # Three pre-seeded entries plus one --add that triggers aging.
+  # All three pre-seeded entries should land at 0.99 * original.
+  mkdir -p "$TESTDIR/a" "$TESTDIR/b" "$TESTDIR/c" "$TESTDIR/trigger"
+  zshz_seed "$TESTDIR/a" 100 60
+  zshz_seed "$TESTDIR/b" 200 60
+  zshz_seed "$TESTDIR/c" 300 60
+  ZSHZ_MAX_SCORE=500 zshz --add "$TESTDIR/trigger"
+
+  # Each pre-seeded rank should now be 0.99 * original. Allow ±0.5
+  # for floating-point representation; the assertions below check
+  # that ranks landed in the aged range, not in the unaged-or-
+  # deleted range.
+  local ra rb rc
+  ra=$(zshz_rank_of "$TESTDIR/a")
+  rb=$(zshz_rank_of "$TESTDIR/b")
+  rc=$(zshz_rank_of "$TESTDIR/c")
+  (( ra < 100 ))  || fail "a should have been aged below 100, was $ra"
+  (( ra > 98.5 )) || fail "a should not have been aged below 98.5, was $ra"
+  (( rb < 200 ))  || fail "b should have been aged below 200, was $rb"
+  (( rb > 197.5 )) || fail "b should not have been aged below 197.5, was $rb"
+  (( rc < 300 ))  || fail "c should have been aged below 300, was $rc"
+  (( rc > 296.5 )) || fail "c should not have been aged below 296.5, was $rc"
+}
+
+test_aging_does_not_delete_entries_above_drop_threshold() {
+  # Entries comfortably above rank 1 must survive aging at their
+  # scaled rank, NOT be filtered out by the `rank_field < 1' drop.
+  # The contrast: rank 1.0 ages to 0.99, falls below the drop
+  # threshold, and is removed on the next rewrite. Rank 5 ages to
+  # 4.95 -- still well above 1, must survive.
+  mkdir -p "$TESTDIR/keep1" "$TESTDIR/keep2" "$TESTDIR/trigger"
+  zshz_seed "$TESTDIR/keep1" 5  60
+  zshz_seed "$TESTDIR/keep2" 50 60
+  ZSHZ_MAX_SCORE=10 zshz --add "$TESTDIR/trigger"
+
+  # Both must still be present (not deleted by aging).
+  assert_ne "" "$(zshz_rank_of "$TESTDIR/keep1")" \
+    "rank-5 entry should not be deleted by aging"
+  assert_ne "" "$(zshz_rank_of "$TESTDIR/keep2")" \
+    "rank-50 entry should not be deleted by aging"
+}
+
+test_aging_preserves_timestamps() {
+  # The aging branch in `_zshz_update_datafile' rewrites each entry
+  # as `$x|$(( 0.99 * rank[$x] ))|${time[$x]}' -- the time field is
+  # passed through verbatim. A regression that touched the time
+  # field during aging would surface here.
+  mkdir -p "$TESTDIR/p" "$TESTDIR/trigger"
+  local now=$EPOCHSECONDS
+  local seeded_ts=$(( now - 12345 ))
+  print "$TESTDIR/p|100|$seeded_ts" >> "$ZSHZ_DATA"
+
+  ZSHZ_MAX_SCORE=50 zshz --add "$TESTDIR/trigger"
+
+  # Read the time field for the seeded entry directly.
+  local stored_ts
+  stored_ts=$(awk -F'|' -v p="$TESTDIR/p" '$1==p { print $3 }' "$ZSHZ_DATA")
+  assert_eq "$seeded_ts" "$stored_ts" \
+    "time field must be preserved through aging"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_basic.zsh
+++ b/tests/test_basic.zsh
@@ -13,7 +13,8 @@ test_add_same_path_twice_increments_rank() {
 
 test_add_skips_HOME() {
   zshz --add "$HOME"
-  local rank=$(zshz_rank_of "$HOME")
+  local rank
+  rank=$(zshz_rank_of "$HOME")
   assert_eq "" "$rank" "\$HOME should not be added"
 }
 
@@ -74,6 +75,7 @@ test_echo_returns_best_match() {
   zshz --add "$a"
   zshz --add "$a"
   zshz --add "$b"
-  local out=$(zshz -e alpha 2>&1)
+  local out
+  out=$(zshz -e alpha 2>&1)
   assert_contains "alpha" "$out" "-e should echo a match for 'alpha'"
 }

--- a/tests/test_basic.zsh
+++ b/tests/test_basic.zsh
@@ -79,3 +79,4 @@ test_echo_returns_best_match() {
   out=$(zshz -e alpha 2>&1)
   assert_contains "alpha" "$out" "-e should echo a match for 'alpha'"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_basic.zsh
+++ b/tests/test_basic.zsh
@@ -1,0 +1,79 @@
+# Smoke tests for the core --add / -x / -l / -e behaviors.
+
+test_add_creates_entry_with_rank_1() {
+  zshz --add "$TESTDIR" || return 1
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR")" "rank after one add"
+}
+
+test_add_same_path_twice_increments_rank() {
+  zshz --add "$TESTDIR"
+  zshz --add "$TESTDIR"
+  assert_eq "2" "$(zshz_rank_of "$TESTDIR")" "rank after two adds"
+}
+
+test_add_skips_HOME() {
+  zshz --add "$HOME"
+  local rank=$(zshz_rank_of "$HOME")
+  assert_eq "" "$rank" "\$HOME should not be added"
+}
+
+test_add_skips_excluded_dir() {
+  local sub="$TESTDIR/excluded"
+  mkdir -p "$sub"
+  ZSHZ_EXCLUDE_DIRS=( "$sub" ) zshz --add "$sub"
+  assert_eq "" "$(zshz_rank_of "$sub")" "excluded dir should not be added"
+}
+
+test_add_skips_subtree_of_excluded_dir() {
+  local sub="$TESTDIR/excluded"
+  mkdir -p "$sub/child"
+  ZSHZ_EXCLUDE_DIRS=( "$sub" ) zshz --add "$sub/child"
+  assert_eq "" "$(zshz_rank_of "$sub/child")" "subtree of excluded dir should not be added"
+}
+
+test_add_nonexistent_path_returns_nonzero() {
+  zshz --add "$TESTDIR/does-not-exist" 2> /dev/null
+  local rc=$?
+  assert_ne "0" "$rc" "adding a missing path should fail"
+}
+
+test_remove_drops_entry() {
+  zshz --add "$TESTDIR"
+  cd "$TESTDIR"
+  zshz -x
+  assert_eq "" "$(zshz_rank_of "$TESTDIR")" "entry should be gone after -x"
+}
+
+test_remove_R_drops_subtree() {
+  local a="$TESTDIR/a" b="$TESTDIR/a/b" c="$TESTDIR/c"
+  mkdir -p "$a" "$b" "$c"
+  zshz --add "$a"
+  zshz --add "$b"
+  zshz --add "$c"
+  cd "$a"
+  zshz -xR
+  assert_eq "" "$(zshz_rank_of "$a")" "$a should be removed"
+  assert_eq "" "$(zshz_rank_of "$b")" "$b (subtree) should be removed"
+  assert_eq "1" "$(zshz_rank_of "$c")" "$c (sibling) should remain"
+}
+
+test_list_shows_added_paths() {
+  local a="$TESTDIR/alpha" b="$TESTDIR/beta"
+  mkdir -p "$a" "$b"
+  zshz --add "$a"
+  zshz --add "$b"
+  local out
+  out=$(zshz -l 2>&1)
+  assert_contains "$a" "$out" "-l should list $a"
+  assert_contains "$b" "$out" "-l should list $b"
+}
+
+test_echo_returns_best_match() {
+  local a="$TESTDIR/alpha" b="$TESTDIR/alphabet"
+  mkdir -p "$a" "$b"
+  zshz --add "$a"
+  zshz --add "$a"
+  zshz --add "$b"
+  local out=$(zshz -e alpha 2>&1)
+  assert_contains "alpha" "$out" "-e should echo a match for 'alpha'"
+}

--- a/tests/test_c_flag.zsh
+++ b/tests/test_c_flag.zsh
@@ -1,0 +1,26 @@
+# -c flag: restrict matches to subdirectories of $PWD.
+#
+# Internally this prepends "$PWD " to the search string and anchors the match
+# at start (zsh-z.plugin.zsh:765, ~858).
+
+test_c_flag_picks_match_under_pwd() {
+  mkdir -p "$TESTDIR/here/sub" "$TESTDIR/elsewhere/sub"
+  zshz --add "$TESTDIR/here/sub"
+  zshz --add "$TESTDIR/elsewhere/sub"
+
+  cd "$TESTDIR/here"
+  local out=$(zshz -ce sub)
+  assert_eq "$TESTDIR/here/sub" "$out" "-c should pick the match inside PWD subtree"
+}
+
+test_c_flag_excludes_paths_outside_pwd() {
+  mkdir -p "$TESTDIR/here" "$TESTDIR/elsewhere/sub"
+  zshz --add "$TESTDIR/elsewhere/sub"
+
+  cd "$TESTDIR/here"
+  local out
+  out=$(zshz -ce sub 2> /dev/null)
+  local rc=$?
+  assert_ne "0" "$rc" "-c should not match outside PWD subtree"
+  assert_eq "" "$out" "no output when nothing under PWD matches"
+}

--- a/tests/test_c_flag.zsh
+++ b/tests/test_c_flag.zsh
@@ -25,3 +25,4 @@ test_c_flag_excludes_paths_outside_pwd() {
   assert_ne "0" "$rc" "-c should not match outside PWD subtree"
   assert_eq "" "$out" "no output when nothing under PWD matches"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_c_flag.zsh
+++ b/tests/test_c_flag.zsh
@@ -9,7 +9,8 @@ test_c_flag_picks_match_under_pwd() {
   zshz --add "$TESTDIR/elsewhere/sub"
 
   cd "$TESTDIR/here"
-  local out=$(zshz -ce sub)
+  local out
+  out=$(zshz -ce sub)
   assert_eq "$TESTDIR/here/sub" "$out" "-c should pick the match inside PWD subtree"
 }
 

--- a/tests/test_c_flag.zsh
+++ b/tests/test_c_flag.zsh
@@ -1,7 +1,7 @@
 # -c flag: restrict matches to subdirectories of $PWD.
 #
-# Internally this prepends "$PWD " to the search string and anchors the match
-# at start (zsh-z.plugin.zsh:765, ~858).
+# The `-c` path prefixes the query with "$PWD " and then matches only from the
+# start of candidate paths, so results must stay within the current subtree.
 
 test_c_flag_picks_match_under_pwd() {
   mkdir -p "$TESTDIR/here/sub" "$TESTDIR/elsewhere/sub"

--- a/tests/test_case.zsh
+++ b/tests/test_case.zsh
@@ -8,7 +8,8 @@
 test_case_default_falls_back_to_insensitive() {
   mkdir -p "$TESTDIR/Foo/Bar"
   zshz --add "$TESTDIR/Foo/Bar"
-  local out=$(zshz -e bar)
+  local out
+  out=$(zshz -e bar)
   assert_eq "$TESTDIR/Foo/Bar" "$out" "default mode should fall back to case-insensitive"
 }
 
@@ -16,7 +17,8 @@ test_case_default_prefers_sensitive_when_both_available() {
   mkdir -p "$TESTDIR/Foo/Bar" "$TESTDIR/foo/bar"
   zshz --add "$TESTDIR/Foo/Bar"
   zshz --add "$TESTDIR/foo/bar"
-  local out=$(zshz -e bar)
+  local out
+  out=$(zshz -e bar)
   assert_eq "$TESTDIR/foo/bar" "$out" "default mode should prefer case-sensitive match"
 }
 
@@ -24,7 +26,8 @@ test_case_ignore_always_insensitive() {
   mkdir -p "$TESTDIR/Foo/Bar"
   zshz --add "$TESTDIR/Foo/Bar"
   ZSHZ_CASE=ignore
-  local out=$(zshz -e bar)
+  local out
+  out=$(zshz -e bar)
   assert_eq "$TESTDIR/Foo/Bar" "$out" "ZSHZ_CASE=ignore should match case-insensitively"
 }
 
@@ -32,7 +35,8 @@ test_case_smart_lowercase_query_is_insensitive() {
   mkdir -p "$TESTDIR/Foo/Bar"
   zshz --add "$TESTDIR/Foo/Bar"
   ZSHZ_CASE=smart
-  local out=$(zshz -e bar)
+  local out
+  out=$(zshz -e bar)
   assert_eq "$TESTDIR/Foo/Bar" "$out" "smart + lowercase query should match insensitively"
 }
 

--- a/tests/test_case.zsh
+++ b/tests/test_case.zsh
@@ -1,0 +1,48 @@
+# ZSHZ_CASE: 'smart', 'ignore', or default.
+#
+# Default: case-sensitive match preferred, case-insensitive as fallback.
+# 'smart':   case-insensitive only if query is all lowercase.
+# 'ignore':  always case-insensitive.
+# (zsh-z.plugin.zsh:681-688)
+
+test_case_default_falls_back_to_insensitive() {
+  mkdir -p "$TESTDIR/Foo/Bar"
+  zshz --add "$TESTDIR/Foo/Bar"
+  local out=$(zshz -e bar)
+  assert_eq "$TESTDIR/Foo/Bar" "$out" "default mode should fall back to case-insensitive"
+}
+
+test_case_default_prefers_sensitive_when_both_available() {
+  mkdir -p "$TESTDIR/Foo/Bar" "$TESTDIR/foo/bar"
+  zshz --add "$TESTDIR/Foo/Bar"
+  zshz --add "$TESTDIR/foo/bar"
+  local out=$(zshz -e bar)
+  assert_eq "$TESTDIR/foo/bar" "$out" "default mode should prefer case-sensitive match"
+}
+
+test_case_ignore_always_insensitive() {
+  mkdir -p "$TESTDIR/Foo/Bar"
+  zshz --add "$TESTDIR/Foo/Bar"
+  ZSHZ_CASE=ignore
+  local out=$(zshz -e bar)
+  assert_eq "$TESTDIR/Foo/Bar" "$out" "ZSHZ_CASE=ignore should match case-insensitively"
+}
+
+test_case_smart_lowercase_query_is_insensitive() {
+  mkdir -p "$TESTDIR/Foo/Bar"
+  zshz --add "$TESTDIR/Foo/Bar"
+  ZSHZ_CASE=smart
+  local out=$(zshz -e bar)
+  assert_eq "$TESTDIR/Foo/Bar" "$out" "smart + lowercase query should match insensitively"
+}
+
+test_case_smart_uppercase_query_is_strict() {
+  mkdir -p "$TESTDIR/foo/bar"
+  zshz --add "$TESTDIR/foo/bar"
+  ZSHZ_CASE=smart
+  local out
+  out=$(zshz -e BAR 2> /dev/null)
+  local rc=$?
+  assert_ne "0" "$rc" "smart + uppercase query should not fall back to insensitive"
+  assert_eq "" "$out" "smart + uppercase query should not match a lowercase path"
+}

--- a/tests/test_case.zsh
+++ b/tests/test_case.zsh
@@ -1,9 +1,9 @@
 # ZSHZ_CASE: 'smart', 'ignore', or default.
 #
-# Default: case-sensitive match preferred, case-insensitive as fallback.
+# `_zshz_find_matches` supports three modes:
+# Default:    case-sensitive match preferred, case-insensitive as fallback.
 # 'smart':   case-insensitive only if query is all lowercase.
 # 'ignore':  always case-insensitive.
-# (zsh-z.plugin.zsh:681-688)
 
 test_case_default_falls_back_to_insensitive() {
   mkdir -p "$TESTDIR/Foo/Bar"

--- a/tests/test_case.zsh
+++ b/tests/test_case.zsh
@@ -50,3 +50,4 @@ test_case_smart_uppercase_query_is_strict() {
   assert_ne "0" "$rc" "smart + uppercase query should not fall back to insensitive"
   assert_eq "" "$out" "smart + uppercase query should not match a lowercase path"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_case.zsh
+++ b/tests/test_case.zsh
@@ -5,6 +5,22 @@
 # 'smart':   case-insensitive only if query is all lowercase.
 # 'ignore':  always case-insensitive.
 
+# Skip tests that need two paths differing only in case to coexist. macOS's
+# default APFS (and HFS+) is case-insensitive, so `foo/bar' and `Foo/Bar'
+# collapse to a single directory there and the case-sensitive tie-break can't
+# be exercised. This is a probe rather than an $OSTYPE match because case
+# sensitivity is a per-volume property, not a per-OS one. Returns 0 (skip) or
+# 1 (run).
+_test_skip_case_insensitive_fs() {
+  local probe=$TESTDIR/.case-probe
+  mkdir -p "$probe" 2>/dev/null
+  local insensitive=1
+  [[ -d $TESTDIR/.CASE-PROBE ]] || insensitive=0
+  rmdir "$probe" 2>/dev/null
+  (( insensitive )) && return 0
+  return 1
+}
+
 test_case_default_falls_back_to_insensitive() {
   mkdir -p "$TESTDIR/Foo/Bar"
   zshz --add "$TESTDIR/Foo/Bar"
@@ -14,6 +30,7 @@ test_case_default_falls_back_to_insensitive() {
 }
 
 test_case_default_prefers_sensitive_when_both_available() {
+  _test_skip_case_insensitive_fs && return 0
   mkdir -p "$TESTDIR/Foo/Bar" "$TESTDIR/foo/bar"
   zshz --add "$TESTDIR/Foo/Bar"
   zshz --add "$TESTDIR/foo/bar"

--- a/tests/test_cd.zsh
+++ b/tests/test_cd.zsh
@@ -14,7 +14,8 @@ test_jump_uses_ZSHZ_CD_when_set() {
 
   cd_capture() { print "captured:$1"; cd "$@" }
   ZSHZ_CD=cd_capture
-  local out=$(zshz foo)
+  local out
+  out=$(zshz foo)
   assert_contains "captured:$TESTDIR/foo" "$out" "ZSHZ_CD function should receive the target path"
 }
 
@@ -24,6 +25,7 @@ test_ZSHZ_CD_supports_multi_word_command() {
 
   capture_multi() { print "multi:$1:$2"; cd "$2" }
   ZSHZ_CD='capture_multi PREFIX'
-  local out=$(zshz foo)
+  local out
+  out=$(zshz foo)
   assert_contains "multi:PREFIX:$TESTDIR/foo" "$out" "ZSHZ_CD value should be word-split via \${=...}"
 }

--- a/tests/test_cd.zsh
+++ b/tests/test_cd.zsh
@@ -29,3 +29,4 @@ test_ZSHZ_CD_supports_multi_word_command() {
   out=$(zshz foo)
   assert_contains "multi:PREFIX:$TESTDIR/foo" "$out" "ZSHZ_CD value should be word-split via \${=...}"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_cd.zsh
+++ b/tests/test_cd.zsh
@@ -1,0 +1,29 @@
+# ZSHZ_CD: substitute a custom directory-changing command (e.g. pushd).
+
+test_jump_uses_default_cd_without_ZSHZ_CD() {
+  mkdir -p "$TESTDIR/foo"
+  zshz --add "$TESTDIR/foo"
+  local out
+  out=$(zshz foo && pwd)
+  assert_eq "$TESTDIR/foo" "$out" "default jump should cd into the matched dir"
+}
+
+test_jump_uses_ZSHZ_CD_when_set() {
+  mkdir -p "$TESTDIR/foo"
+  zshz --add "$TESTDIR/foo"
+
+  cd_capture() { print "captured:$1"; cd "$@" }
+  ZSHZ_CD=cd_capture
+  local out=$(zshz foo)
+  assert_contains "captured:$TESTDIR/foo" "$out" "ZSHZ_CD function should receive the target path"
+}
+
+test_ZSHZ_CD_supports_multi_word_command() {
+  mkdir -p "$TESTDIR/foo"
+  zshz --add "$TESTDIR/foo"
+
+  capture_multi() { print "multi:$1:$2"; cd "$2" }
+  ZSHZ_CD='capture_multi PREFIX'
+  local out=$(zshz foo)
+  assert_contains "multi:PREFIX:$TESTDIR/foo" "$out" "ZSHZ_CD value should be word-split via \${=...}"
+}

--- a/tests/test_cleanup.zsh
+++ b/tests/test_cleanup.zsh
@@ -37,3 +37,4 @@ test_keep_dirs_protects_exact_match() {
 
   assert_eq "1" "$(zshz_rank_of "$TESTDIR/exact")" "exact-match KEEP_DIRS entry should survive"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_cleanup.zsh
+++ b/tests/test_cleanup.zsh
@@ -1,0 +1,39 @@
+# Stale-entry cleanup and ZSHZ_KEEP_DIRS.
+#
+# Entries whose paths no longer exist on disk are pruned from the datafile
+# on the next write (zsh-z.plugin.zsh:363-377). ZSHZ_KEEP_DIRS shields a
+# subtree from that pruning, useful for ephemeral mounts.
+
+test_stale_entry_pruned_on_next_write() {
+  mkdir -p "$TESTDIR/keep" "$TESTDIR/gone"
+  zshz --add "$TESTDIR/keep"
+  zshz --add "$TESTDIR/gone"
+  rm -rf "$TESTDIR/gone"
+
+  zshz --add "$TESTDIR/keep"  # forces a write -> triggers prune
+
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/gone")" "missing dir should be pruned"
+  assert_ne "" "$(zshz_rank_of "$TESTDIR/keep")" "existing dir should remain"
+}
+
+test_keep_dirs_protects_subtree() {
+  mkdir -p "$TESTDIR/holdme/x" "$TESTDIR/lose" "$TESTDIR/trigger"
+  zshz --add "$TESTDIR/holdme/x"
+  zshz --add "$TESTDIR/lose"
+  rm -rf "$TESTDIR/holdme" "$TESTDIR/lose"
+
+  ZSHZ_KEEP_DIRS=( "$TESTDIR/holdme" ) zshz --add "$TESTDIR/trigger"
+
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/holdme/x")" "subtree under KEEP_DIRS should survive"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/lose")" "non-kept missing entry should be pruned"
+}
+
+test_keep_dirs_protects_exact_match() {
+  mkdir -p "$TESTDIR/exact" "$TESTDIR/trigger"
+  zshz --add "$TESTDIR/exact"
+  rm -rf "$TESTDIR/exact"
+
+  ZSHZ_KEEP_DIRS=( "$TESTDIR/exact" ) zshz --add "$TESTDIR/trigger"
+
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/exact")" "exact-match KEEP_DIRS entry should survive"
+}

--- a/tests/test_cleanup.zsh
+++ b/tests/test_cleanup.zsh
@@ -1,8 +1,8 @@
 # Stale-entry cleanup and ZSHZ_KEEP_DIRS.
 #
-# Entries whose paths no longer exist on disk are pruned from the datafile
-# on the next write (zsh-z.plugin.zsh:363-377). ZSHZ_KEEP_DIRS shields a
-# subtree from that pruning, useful for ephemeral mounts.
+# `_zshz_update_datafile` drops entries whose directories no longer exist when
+# it rewrites the database. `ZSHZ_KEEP_DIRS` exempts matching paths and their
+# subtrees from that cleanup, which is useful for ephemeral mounts.
 
 test_stale_entry_pruned_on_next_write() {
   mkdir -p "$TESTDIR/keep" "$TESTDIR/gone"

--- a/tests/test_cli.zsh
+++ b/tests/test_cli.zsh
@@ -1,0 +1,31 @@
+# Help and invalid-option handling.
+
+test_help_short_prints_usage() {
+  local out rc
+  out=$(zshz -h 2>&1)
+  rc=$?
+
+  assert_eq "0" "$rc" "-h should succeed"
+  assert_contains "Usage: z" "$out" "-h should print usage"
+  assert_contains "--add Add a directory to the database" "$out" "-h should include option help"
+}
+
+test_help_long_prints_usage() {
+  local out rc
+  out=$(zshz --help 2>&1)
+  rc=$?
+
+  assert_eq "0" "$rc" "--help should succeed"
+  assert_contains "Usage: z" "$out" "--help should print usage"
+  assert_contains "-xR   Remove a directory and its subdirectories" "$out" "--help should include detailed options"
+}
+
+test_invalid_option_prints_error_and_usage() {
+  local out rc
+  out=$(zshz -q 2>&1)
+  rc=$?
+
+  assert_ne "0" "$rc" "invalid option should fail"
+  assert_contains "Improper option(s) given." "$out" "invalid option should print an error"
+  assert_contains "Usage: z" "$out" "invalid option should also print usage"
+}

--- a/tests/test_cli.zsh
+++ b/tests/test_cli.zsh
@@ -29,3 +29,4 @@ test_invalid_option_prints_error_and_usage() {
   assert_contains "Improper option(s) given." "$out" "invalid option should print an error"
   assert_contains "Usage: z" "$out" "invalid option should also print usage"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_cli.zsh
+++ b/tests/test_cli.zsh
@@ -29,4 +29,33 @@ test_invalid_option_prints_error_and_usage() {
   assert_contains "Improper option(s) given." "$out" "invalid option should print an error"
   assert_contains "Usage: z" "$out" "invalid option should also print usage"
 }
+
+test_complete_does_not_trigger_add_side_effect() {
+  # Regression: tab completion of `z --add <dir>` reaches zshz as
+  # `zshz --complete --add <dir>`. zparseopts captures both flags, so the
+  # for-loop used to also run the --add branch and silently write to the
+  # datafile. --complete must stay side-effect-free.
+  zshz --complete --add "$TESTDIR" > /dev/null
+  assert_eq "" "$(zshz_rank_of "$TESTDIR")" \
+    "'--complete --add' must not write to the datafile"
+}
+
+test_complete_does_not_trigger_remove_side_effect() {
+  zshz --add "$TESTDIR"
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR")" "precondition: entry should exist"
+  cd "$TESTDIR"
+  zshz --complete -x > /dev/null
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR")" \
+    "'--complete -x' must not remove entries"
+}
+
+test_complete_help_combo_is_silent() {
+  # --help under --complete must not emit the usage banner; the runner already
+  # treats any stderr as a failure, but assert explicitly so the intent is clear.
+  local out err
+  out=$(zshz --complete --help 2> /dev/null)
+  err=$(zshz --complete --help 2>&1 > /dev/null)
+  assert_not_contains "Usage: z" "$out" "'--complete --help' must not print usage to stdout"
+  assert_not_contains "Usage: z" "$err" "'--complete --help' must not print usage to stderr"
+}
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_common_root.zsh
+++ b/tests/test_common_root.zsh
@@ -1,0 +1,111 @@
+# Pin `_zshz_find_common_root' behaviour across input orderings and
+# structures.
+#
+# `_zshz_find_common_root' is nested inside `zshz()' and not callable
+# directly; these tests drive it through `zshz -e <query>' against
+# datafiles seeded in deliberate orders. The associative-array
+# iteration order in `_zshz_find_common_root' depends on insertion
+# order, so seeding the same entries in different orders can exercise
+# different paths through the loop. The existing
+# `test_default_returns_common_root_when_one_exists' in test_uncommon.zsh
+# covers a single ordering of one structure; this file pins the
+# algorithm against the broader space before any tightening.
+#
+# Output assertions all run with default settings (ZSHZ_UNCOMMON unset),
+# in which case `_zshz_output' returns the common root when one is
+# found and falls back to the highest-ranked match otherwise.
+
+test_common_root_seeded_root_first() {
+  mkdir -p "$TESTDIR/croot/sub1" "$TESTDIR/croot/sub2"
+  zshz_seed "$TESTDIR/croot"      1   60
+  zshz_seed "$TESTDIR/croot/sub1" 100 60
+  zshz_seed "$TESTDIR/croot/sub2" 50  60
+
+  local out
+  out=$(zshz -e croot)
+  assert_eq "$TESTDIR/croot" "$out" \
+    "common root should be returned when seeded first"
+}
+
+test_common_root_seeded_root_middle() {
+  mkdir -p "$TESTDIR/croot/sub1" "$TESTDIR/croot/sub2"
+  zshz_seed "$TESTDIR/croot/sub1" 100 60
+  zshz_seed "$TESTDIR/croot"      1   60
+  zshz_seed "$TESTDIR/croot/sub2" 50  60
+
+  local out
+  out=$(zshz -e croot)
+  assert_eq "$TESTDIR/croot" "$out" \
+    "common root should be returned when seeded between siblings"
+}
+
+test_common_root_seeded_root_last() {
+  mkdir -p "$TESTDIR/croot/sub1" "$TESTDIR/croot/sub2"
+  zshz_seed "$TESTDIR/croot/sub1" 100 60
+  zshz_seed "$TESTDIR/croot/sub2" 50  60
+  zshz_seed "$TESTDIR/croot"      1   60
+
+  local out
+  out=$(zshz -e croot)
+  assert_eq "$TESTDIR/croot" "$out" \
+    "common root should be returned when seeded last"
+}
+
+test_common_root_no_root_entry_picks_highest_ranked() {
+  # No entry for the actual common ancestor `$TESTDIR/croot'; only
+  # siblings are present. `_zshz_find_common_root' can't return an
+  # ancestor that isn't in the input set, so the second loop should
+  # find no agreement, and `_zshz_output' should fall through to the
+  # highest-ranked match.
+  mkdir -p "$TESTDIR/croot/sub1" "$TESTDIR/croot/sub2"
+  zshz_seed "$TESTDIR/croot/sub1" 100 60
+  zshz_seed "$TESTDIR/croot/sub2" 50  60
+
+  local out
+  out=$(zshz -e croot)
+  assert_eq "$TESTDIR/croot/sub1" "$out" \
+    "without a common-root entry, the highest-ranked sibling should win"
+}
+
+test_common_root_mixed_depth_under_one_root() {
+  # Three paths, depths 1, 2, 3, all under the same root. The shortest
+  # (`$TESTDIR/croot') is the common root and is in the input set, so
+  # the function should pick it regardless of which is highest-ranked.
+  mkdir -p "$TESTDIR/croot/a/b"
+  zshz_seed "$TESTDIR/croot/a/b" 100 60
+  zshz_seed "$TESTDIR/croot/a"   50  60
+  zshz_seed "$TESTDIR/croot"     1   60
+
+  local out
+  out=$(zshz -e croot)
+  assert_eq "$TESTDIR/croot" "$out" \
+    "common root should win against deeper higher-ranked descendants"
+}
+
+test_common_root_deep_with_irrelevant_high_rank_neighbour() {
+  # A high-ranked entry that doesn't match the query shouldn't enter
+  # `matches' at all and shouldn't influence the common-root choice.
+  mkdir -p "$TESTDIR/croot/sub1" "$TESTDIR/croot/sub2" "$TESTDIR/elsewhere"
+  zshz_seed "$TESTDIR/croot"      1    60
+  zshz_seed "$TESTDIR/croot/sub1" 50   60
+  zshz_seed "$TESTDIR/croot/sub2" 100  60
+  zshz_seed "$TESTDIR/elsewhere"  9999 60   # unrelated, high rank
+
+  local out
+  out=$(zshz -e croot)
+  assert_eq "$TESTDIR/croot" "$out" \
+    "high-rank non-matching entry must not perturb the common-root choice"
+}
+
+test_common_root_single_match_returns_full_path() {
+  # If only one entry matches, there's no "common root" to compute --
+  # the single match itself is the answer.
+  mkdir -p "$TESTDIR/onlyone"
+  zshz_seed "$TESTDIR/onlyone" 10 60
+
+  local out
+  out=$(zshz -e onlyone)
+  assert_eq "$TESTDIR/onlyone" "$out" \
+    "single match should be returned as-is"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_complete_aliases.zsh
+++ b/tests/test_complete_aliases.zsh
@@ -1,0 +1,113 @@
+# Tab completion under `setopt COMPLETE_ALIASES'.
+#
+# compinit parses the static `#compdef' tag in `_zshz' literally -- the
+# `${ZSHZ_CMD:-...}' part of `#compdef zshz ${ZSHZ_CMD:-${_Z_CMD:-z}}' is
+# never expanded, so only the literal `zshz' command gets registered at
+# compinit time. Without COMPLETE_ALIASES that's enough: zsh expands the
+# alias `z' -> `zshz 2>&1' before the completion lookup, so `_comps[zshz]'
+# is consulted. Under COMPLETE_ALIASES the lookup is verbatim and would
+# miss `_zshz' entirely.
+#
+# The widget compensates by populating `_comps[$cmd]' on first invocation,
+# guarded by `(( ${+_comps[$cmd]} ))' so a user-defined completer for the
+# same name is left alone. We can't drive a real ZLE session
+# non-interactively, so each test stubs `zle' and calls the widget directly.
+
+test_alias_is_defined_after_sourcing() {
+  local out
+  out=$(zsh --no-rcs -c "
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    print -- \${aliases[z]:-NONE}
+  ")
+  assert_eq "zshz 2>&1" "$out" "alias z should be 'zshz 2>&1' after sourcing"
+}
+
+test_static_compdef_registers_zshz_literal() {
+  # Sanity check: compinit picks up the literal `zshz' from the #compdef tag.
+  # This is what makes tab completion work without COMPLETE_ALIASES (zsh
+  # expands the alias first, then looks up `_comps[zshz]').
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    fpath=( '$PLUGIN_DIR' \$fpath )
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    autoload -U compinit
+    compinit -u -d \$(mktemp -u) 2> /dev/null
+    print -- \${_comps[zshz]:-NONE}
+  ")
+  assert_eq "_zshz" "$out" "_comps[zshz] should be set by the static #compdef tag"
+}
+
+test_widget_registers_alias_on_first_invocation() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    fpath=( '$PLUGIN_DIR' \$fpath )
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    autoload -U compinit
+    compinit -u -d \$(mktemp -u) 2> /dev/null
+    [[ -z \${_comps[z]:-} ]] || { print 'precondition failed: _comps[z] already set'; exit 1 }
+    zle() { return 0 }
+    LBUFFER='z foo'
+    _zshz_zle_completion_widget
+    print -- \${_comps[z]:-NONE}
+  ")
+  assert_eq "_zshz" "$out" "first widget call should register _comps[z]"
+}
+
+test_widget_registers_alias_under_complete_aliases() {
+  # The headline COMPLETE_ALIASES scenario: with the option set, zsh looks up
+  # the completion by the alias name verbatim, so `_comps[z]' has to be _zshz.
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    setopt COMPLETE_ALIASES
+    fpath=( '$PLUGIN_DIR' \$fpath )
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    autoload -U compinit
+    compinit -u -d \$(mktemp -u) 2> /dev/null
+    zle() { return 0 }
+    LBUFFER='z foo'
+    _zshz_zle_completion_widget
+    print -- \${_comps[z]:-NONE}
+  ")
+  assert_eq "_zshz" "$out" "_comps[z] must be _zshz after one widget call under COMPLETE_ALIASES"
+}
+
+test_widget_registers_alias_for_custom_ZSHZ_CMD() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    ZSHZ_CMD=zoo
+    fpath=( '$PLUGIN_DIR' \$fpath )
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    autoload -U compinit
+    compinit -u -d \$(mktemp -u) 2> /dev/null
+    zle() { return 0 }
+    LBUFFER='zoo foo'
+    _zshz_zle_completion_widget
+    print -- \${_comps[zoo]:-NONE}
+  ")
+  assert_eq "_zshz" "$out" "_comps[zoo] should be set when ZSHZ_CMD=zoo"
+}
+
+test_widget_does_not_overwrite_existing_comps_entry() {
+  # If the user has already mapped the alias name to another completer, the
+  # guard `(( ${+_comps[$cmd]} )) ||' must defer rather than clobber.
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    fpath=( '$PLUGIN_DIR' \$fpath )
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    autoload -U compinit
+    compinit -u -d \$(mktemp -u) 2> /dev/null
+    _comps[z]=_some_other_completer
+    zle() { return 0 }
+    LBUFFER='z foo'
+    _zshz_zle_completion_widget
+    print -- \${_comps[z]:-NONE}
+  ")
+  assert_eq "_some_other_completer" "$out" "pre-existing _comps[\$cmd] must not be overwritten"
+}
+
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_completion_legacy.zsh
+++ b/tests/test_completion_legacy.zsh
@@ -30,3 +30,4 @@ test_legacy_complete_trailing_slash_matches_directory_end() {
   assert_contains "$TESTDIR/root/foo" "$on" "TRAILING_SLASH should allow matching a directory end"
   assert_not_contains "$TESTDIR/root/foobar" "$on" "TRAILING_SLASH should not match longer sibling names"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_completion_legacy.zsh
+++ b/tests/test_completion_legacy.zsh
@@ -1,0 +1,35 @@
+# Legacy completion mode and ZSHZ_TRAILING_SLASH.
+
+test_legacy_complete_returns_matches() {
+  mkdir -p "$TESTDIR/foo/bar" "$TESTDIR/foo/baz" "$TESTDIR/qux"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/foo/bar|1|$now" \
+    "$TESTDIR/foo/baz|1|$now" \
+    "$TESTDIR/qux|1|$now" \
+    > "$ZSHZ_DATA"
+
+  ZSHZ_COMPLETION=legacy
+  local out=$(zshz --complete foo)
+  assert_contains "$TESTDIR/foo/bar" "$out" "legacy completion should include matching paths"
+  assert_contains "$TESTDIR/foo/baz" "$out" "legacy completion should include all matching paths"
+  assert_not_contains "$TESTDIR/qux" "$out" "legacy completion should exclude non-matches"
+}
+
+test_legacy_complete_trailing_slash_matches_directory_end() {
+  mkdir -p "$TESTDIR/root/foo" "$TESTDIR/root/foobar"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/root/foo|1|$now" \
+    "$TESTDIR/root/foobar|1|$now" \
+    > "$ZSHZ_DATA"
+
+  ZSHZ_COMPLETION=legacy
+  local off=$(zshz --complete 'foo/')
+  assert_eq "" "$off" "without TRAILING_SLASH, query ending in / should not match a path ending in foo"
+
+  ZSHZ_TRAILING_SLASH=1
+  local on=$(zshz --complete 'foo/')
+  assert_contains "$TESTDIR/root/foo" "$on" "TRAILING_SLASH should allow matching a directory end"
+  assert_not_contains "$TESTDIR/root/foobar" "$on" "TRAILING_SLASH should not match longer sibling names"
+}

--- a/tests/test_completion_legacy.zsh
+++ b/tests/test_completion_legacy.zsh
@@ -7,7 +7,8 @@ test_legacy_complete_returns_matches() {
   zshz_seed "$TESTDIR/qux" 1
 
   ZSHZ_COMPLETION=legacy
-  local out=$(zshz --complete foo)
+  local out
+  out=$(zshz --complete foo)
   assert_contains "$TESTDIR/foo/bar" "$out" "legacy completion should include matching paths"
   assert_contains "$TESTDIR/foo/baz" "$out" "legacy completion should include all matching paths"
   assert_not_contains "$TESTDIR/qux" "$out" "legacy completion should exclude non-matches"
@@ -19,11 +20,13 @@ test_legacy_complete_trailing_slash_matches_directory_end() {
   zshz_seed "$TESTDIR/root/foobar" 1
 
   ZSHZ_COMPLETION=legacy
-  local off=$(zshz --complete 'foo/')
+  local off
+  off=$(zshz --complete 'foo/')
   assert_eq "" "$off" "without TRAILING_SLASH, query ending in / should not match a path ending in foo"
 
   ZSHZ_TRAILING_SLASH=1
-  local on=$(zshz --complete 'foo/')
+  local on
+  on=$(zshz --complete 'foo/')
   assert_contains "$TESTDIR/root/foo" "$on" "TRAILING_SLASH should allow matching a directory end"
   assert_not_contains "$TESTDIR/root/foobar" "$on" "TRAILING_SLASH should not match longer sibling names"
 }

--- a/tests/test_completion_legacy.zsh
+++ b/tests/test_completion_legacy.zsh
@@ -2,12 +2,9 @@
 
 test_legacy_complete_returns_matches() {
   mkdir -p "$TESTDIR/foo/bar" "$TESTDIR/foo/baz" "$TESTDIR/qux"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/foo/bar|1|$now" \
-    "$TESTDIR/foo/baz|1|$now" \
-    "$TESTDIR/qux|1|$now" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/foo/bar" 1
+  zshz_seed "$TESTDIR/foo/baz" 1
+  zshz_seed "$TESTDIR/qux" 1
 
   ZSHZ_COMPLETION=legacy
   local out=$(zshz --complete foo)
@@ -18,11 +15,8 @@ test_legacy_complete_returns_matches() {
 
 test_legacy_complete_trailing_slash_matches_directory_end() {
   mkdir -p "$TESTDIR/root/foo" "$TESTDIR/root/foobar"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/root/foo|1|$now" \
-    "$TESTDIR/root/foobar|1|$now" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/root/foo" 1
+  zshz_seed "$TESTDIR/root/foobar" 1
 
   ZSHZ_COMPLETION=legacy
   local off=$(zshz --complete 'foo/')

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -5,33 +5,28 @@
 # replaced via mv) so concurrent writers did not actually serialize.
 
 test_concurrent_add_no_lost_updates() {
-  local n=20 i p
+  local n=20 i
   local target="$TESTDIR/target"
   mkdir -p "$target"
 
-  local pids=()
   for i in $(seq 1 $n); do
     ( zshz --add "$target" ) &
-    pids+=( $! )
   done
-  for p in $pids; do wait $p; done
+  wait
 
   assert_eq "$n" "$(zshz_rank_of "$target")" "$n concurrent adds should produce rank $n"
 }
 
 test_concurrent_add_two_paths_each_independent() {
-  local n=15 i p
+  local n=15 i
   local a="$TESTDIR/a" b="$TESTDIR/b"
   mkdir -p "$a" "$b"
 
-  local pids=()
   for i in $(seq 1 $n); do
     ( zshz --add "$a" ) &
-    pids+=( $! )
     ( zshz --add "$b" ) &
-    pids+=( $! )
   done
-  for p in $pids; do wait $p; done
+  wait
 
   assert_eq "$n" "$(zshz_rank_of "$a")" "$n concurrent adds to a"
   assert_eq "$n" "$(zshz_rank_of "$b")" "$n concurrent adds to b"

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -3,16 +3,20 @@
 # Before the fix, the read-modify-write cycle was racy: lines was read before
 # the lock was acquired, and the lock was held on $datafile (whose inode is
 # replaced via mv) so concurrent writers did not actually serialize.
+#
+# Each writer is spawned as an independent `zsh -c` process via xargs rather
+# than as a backgrounded subshell of the test runner. This exercises the
+# plugin's flock-based serialization across real OS processes (closer to real
+# usage: multiple terminals, each their own zsh) and avoids zsh 4.3.11's
+# `&`/`wait` machinery, which segfaults under even light fork load.
 
 test_concurrent_add_no_lost_updates() {
-  local n=20 i
+  local n=20
   local target="$TESTDIR/target"
   mkdir -p "$target"
 
-  for i in $(seq 1 $n); do
-    ( zshz --add "$target" ) &
-  done
-  wait
+  seq 1 $n | xargs -P 4 -I{} \
+    zsh -c "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '$target'"
 
   assert_eq "$n" "$(zshz_rank_of "$target")" "$n concurrent adds should produce rank $n"
 }
@@ -22,11 +26,15 @@ test_concurrent_add_two_paths_each_independent() {
   local a="$TESTDIR/a" b="$TESTDIR/b"
   mkdir -p "$a" "$b"
 
-  for i in $(seq 1 $n); do
-    ( zshz --add "$a" ) &
-    ( zshz --add "$b" ) &
-  done
-  wait
+  # Interleave a and b on the input list so xargs runs adds for both paths
+  # concurrently (rather than draining one before starting the other).
+  {
+    for ((i=1; i<=n; i++)); do
+      print -- "$a"
+      print -- "$b"
+    done
+  } | xargs -P 4 -I{} \
+        zsh -c "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '{}'"
 
   assert_eq "$n" "$(zshz_rank_of "$a")" "$n concurrent adds to a"
   assert_eq "$n" "$(zshz_rank_of "$b")" "$n concurrent adds to b"

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -9,6 +9,12 @@
 # plugin's flock-based serialization across real OS processes (closer to real
 # usage: multiple terminals, each their own zsh) and avoids zsh 4.3.11's
 # `&`/`wait` machinery, which segfaults under even light fork load.
+#
+# The plugin's default lock timeout (ZSHZ_LOCK_TIMEOUT=1s) is meant to keep
+# stuck holders from freezing the prompt; under heavy concurrent load that
+# bound is too tight and writers would time out and silently drop updates.
+# The tests bump the timeout via env so honest contention isn't mistaken
+# for a regression.
 
 test_concurrent_add_no_lost_updates() {
   local n=20
@@ -16,7 +22,8 @@ test_concurrent_add_no_lost_updates() {
   mkdir -p "$target"
 
   seq 1 $n | xargs -P 4 -I{} \
-    zsh -c "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '$target'"
+    env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
+      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '$target'"
 
   assert_eq "$n" "$(zshz_rank_of "$target")" "$n concurrent adds should produce rank $n"
 }
@@ -34,7 +41,8 @@ test_concurrent_add_two_paths_each_independent() {
       print -- "$b"
     done
   } | xargs -P 4 -I{} \
-        zsh -c "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '{}'"
+        env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
+          "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '{}'"
 
   assert_eq "$n" "$(zshz_rank_of "$a")" "$n concurrent adds to a"
   assert_eq "$n" "$(zshz_rank_of "$b")" "$n concurrent adds to b"

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -28,6 +28,33 @@ test_concurrent_add_no_lost_updates() {
   assert_eq "$n" "$(zshz_rank_of "$target")" "$n concurrent adds should produce rank $n"
 }
 
+test_lock_fd_does_not_leak_across_repeated_adds() {
+  # zsystem flock -f opens an fd that persists for the shell process's
+  # lifetime; without an explicit zsystem flock -u, the fcntl lock stays
+  # held until the shell exits. POSIX advisory locks are per-process, so
+  # the leaking shell never notices, but peers block on F_SETLKW until
+  # ZSHZ_LOCK_TIMEOUT and silently drop their update.
+  #
+  # This shell is the runner: do two --add calls so any leaked fd would
+  # still be held when we spawn the external writer. The external shell
+  # uses a tight 1s timeout: if the runner leaked, it would time out and
+  # the rank would not land.
+  local a="$TESTDIR/leak-a" b="$TESTDIR/leak-b" c="$TESTDIR/leak-c"
+  mkdir -p "$a" "$b" "$c"
+  zshz --add "$a"
+  zshz --add "$b"
+
+  local rc
+  env ZSHZ_LOCK_TIMEOUT=1 zsh --no-rcs -c "
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zshz --add '$c'
+  " > /dev/null 2>&1
+  rc=$?
+
+  assert_eq "0" "$rc" "external --add should not time out waiting on a leaked lock"
+  assert_eq "1" "$(zshz_rank_of "$c")" "external --add should have landed in the datafile"
+}
+
 test_concurrent_add_two_paths_each_independent() {
   local n=15 i
   local a="$TESTDIR/a" b="$TESTDIR/b"

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -1,0 +1,38 @@
+# Regression tests for concurrent --add / -x writes.
+#
+# Before the fix, the read-modify-write cycle was racy: lines was read before
+# the lock was acquired, and the lock was held on $datafile (whose inode is
+# replaced via mv) so concurrent writers did not actually serialize.
+
+test_concurrent_add_no_lost_updates() {
+  local n=20 i p
+  local target="$TESTDIR/target"
+  mkdir -p "$target"
+
+  local pids=()
+  for i in $(seq 1 $n); do
+    ( zshz --add "$target" ) &
+    pids+=( $! )
+  done
+  for p in $pids; do wait $p; done
+
+  assert_eq "$n" "$(zshz_rank_of "$target")" "$n concurrent adds should produce rank $n"
+}
+
+test_concurrent_add_two_paths_each_independent() {
+  local n=15 i p
+  local a="$TESTDIR/a" b="$TESTDIR/b"
+  mkdir -p "$a" "$b"
+
+  local pids=()
+  for i in $(seq 1 $n); do
+    ( zshz --add "$a" ) &
+    pids+=( $! )
+    ( zshz --add "$b" ) &
+    pids+=( $! )
+  done
+  for p in $pids; do wait $p; done
+
+  assert_eq "$n" "$(zshz_rank_of "$a")" "$n concurrent adds to a"
+  assert_eq "$n" "$(zshz_rank_of "$b")" "$n concurrent adds to b"
+}

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -31,3 +31,4 @@ test_concurrent_add_two_paths_each_independent() {
   assert_eq "$n" "$(zshz_rank_of "$a")" "$n concurrent adds to a"
   assert_eq "$n" "$(zshz_rank_of "$b")" "$n concurrent adds to b"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -17,6 +17,14 @@
 # for a regression.
 
 test_concurrent_add_no_lost_updates() {
+  # Without `zsystem flock', the plugin's no-lock fallback can't
+  # serialize cross-process writers -- each one reads its own
+  # snapshot and the last `mv' wins. Skip on environments without
+  # `zsh/system' (e.g. MobaXterm's Cygwin).
+  if ! (( ZSHZ[USE_FLOCK] )); then
+    print "skip: zsystem flock unavailable"
+    return 0
+  fi
   local n=20
   local target="$TESTDIR/target"
   mkdir -p "$target"
@@ -39,6 +47,10 @@ test_lock_fd_does_not_leak_across_repeated_adds() {
   # still be held when we spawn the external writer. The external shell
   # uses a tight 1s timeout: if the runner leaked, it would time out and
   # the rank would not land.
+  if ! (( ZSHZ[USE_FLOCK] )); then
+    print "skip: zsystem flock unavailable"
+    return 0
+  fi
   local a="$TESTDIR/leak-a" b="$TESTDIR/leak-b" c="$TESTDIR/leak-c"
   mkdir -p "$a" "$b" "$c"
   zshz --add "$a"
@@ -56,6 +68,10 @@ test_lock_fd_does_not_leak_across_repeated_adds() {
 }
 
 test_concurrent_add_two_paths_each_independent() {
+  if ! (( ZSHZ[USE_FLOCK] )); then
+    print "skip: zsystem flock unavailable"
+    return 0
+  fi
   local n=15 i
   local a="$TESTDIR/a" b="$TESTDIR/b"
   mkdir -p "$a" "$b"

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -21,9 +21,9 @@ test_concurrent_add_no_lost_updates() {
   local target="$TESTDIR/target"
   mkdir -p "$target"
 
-  seq 1 $n | xargs_P 4 \
+  seq 1 $n | ( xargs_P 4 \
     env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
-      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '$target'"
+      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '$target'" )
 
   assert_eq "$n" "$(zshz_rank_of "$target")" "$n concurrent adds should produce rank $n"
 }
@@ -67,9 +67,9 @@ test_concurrent_add_two_paths_each_independent() {
       print -- "$a"
       print -- "$b"
     done
-  } | xargs_P 4 \
+  } | ( xargs_P 4 \
         env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
-          "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '{}'"
+          "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '{}'" )
 
   assert_eq "$n" "$(zshz_rank_of "$a")" "$n concurrent adds to a"
   assert_eq "$n" "$(zshz_rank_of "$b")" "$n concurrent adds to b"

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -15,6 +15,12 @@
 # bound is too tight and writers would time out and silently drop updates.
 # The tests bump the timeout via env so honest contention isn't mistaken
 # for a regression.
+#
+# `test_concurrent_add_no_lost_updates' below is the fast, CI-bounded
+# (n=20) regression gate. Its heavy, tunable, manual counterpart is
+# tests/stress.sh, which cranks N/PARALLEL high and can target an
+# arbitrary zsh binary. Keep the shared invariant (datafile format,
+# rank==N, ZSHZ_LOCK_TIMEOUT) in sync between the two.
 
 test_concurrent_add_no_lost_updates() {
   # Without `zsystem flock', the plugin's no-lock fallback can't

--- a/tests/test_concurrency.zsh
+++ b/tests/test_concurrency.zsh
@@ -21,7 +21,7 @@ test_concurrent_add_no_lost_updates() {
   local target="$TESTDIR/target"
   mkdir -p "$target"
 
-  seq 1 $n | xargs -P 4 -I{} \
+  seq 1 $n | xargs_P 4 \
     env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
       "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '$target'"
 
@@ -67,7 +67,7 @@ test_concurrent_add_two_paths_each_independent() {
       print -- "$a"
       print -- "$b"
     done
-  } | xargs -P 4 -I{} \
+  } | xargs_P 4 \
         env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
           "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add '{}'"
 

--- a/tests/test_concurrent_mixed.zsh
+++ b/tests/test_concurrent_mixed.zsh
@@ -1,0 +1,68 @@
+# Concurrent `--add' and `-x' against the same and overlapping paths.
+#
+# The existing `test_concurrent_add_no_lost_updates' covers
+# concurrent adds-only. This file covers the mixed case: some writers
+# add, others remove, all racing for the same lockfile. We don't pin
+# the exact rank of any path -- with adds and removes interleaved, the
+# final rank depends on the order the lock is acquired -- but we do
+# pin two structural invariants:
+#
+#   1. Every line in the datafile matches the canonical
+#      `/path|rank|time' shape after the dust settles. A torn write
+#      or a rewrite of a half-parsed datafile would surface as a
+#      malformed line here.
+#   2. No `${datafile}.${RANDOM}' tempfiles are left behind. The
+#      `_zshz_add_or_remove_path' rewrite path either renames its
+#      tempfile over the datafile or `rm -f's it on failure; an
+#      orphan would mean a code path leaked one.
+#
+# Spawned via xargs (rather than `&'/`wait' from the test shell) for
+# the same reason `test_concurrency.zsh' does -- zsh 4.3.11's job
+# machinery segfaults under fork load.
+
+test_concurrent_add_and_remove_interleaved() {
+  local a="$TESTDIR/A" b="$TESTDIR/B" c="$TESTDIR/C" d="$TESTDIR/D"
+  mkdir -p "$a" "$b" "$c" "$d"
+
+  # Build a deliberately interleaved mix of adds and removes. D never
+  # gets removed, so it's guaranteed to be in the datafile at the end
+  # -- prevents the test from passing trivially if every operation
+  # got dropped.
+  local -a ops
+  ops=(
+    "--add $a" "--add $b" "--add $c" "--add $d"
+    "--add $a" "--add $b" "--add $c" "--add $d"
+    "--add $a" "--add $b" "--add $c" "--add $d"
+    "-x $a"   "-x $a"
+    "-x $c"
+    "--add $a" "--add $b" "--add $c" "--add $d"
+    "-x $b"
+    "--add $a" "--add $b"
+    "-x $c"
+  )
+
+  printf '%s\n' "${ops[@]}" | xargs -P 4 -I {} \
+    env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
+      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz {} > /dev/null 2>&1"
+
+  # 1. Datafile is non-empty and every line is well-formed.
+  [[ -s $ZSHZ_DATA ]] || fail "datafile is empty after ${#ops} operations"
+  local line line_no=0
+  while IFS= read -r line; do
+    (( line_no++ ))
+    [[ $line == /*\|[0-9]##(.[0-9]#)#\|[0-9]## ]] || \
+      fail "datafile line $line_no is malformed: $line"
+  done < "$ZSHZ_DATA"
+
+  # D never got an `-x', so it must be present.
+  [[ -n $(zshz_rank_of "$d") ]] || \
+    fail "D should be in the datafile (only added, never removed)"
+
+  # 2. No orphaned tempfiles. The plugin uses ${datafile}.${RANDOM}.
+  local -a tempfiles
+  tempfiles=( "${ZSHZ_DATA}".<->(N) )
+  if (( ${#tempfiles} )); then
+    fail "orphaned tempfile(s): ${(j:, :)tempfiles}"
+  fi
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_concurrent_mixed.zsh
+++ b/tests/test_concurrent_mixed.zsh
@@ -41,9 +41,9 @@ test_concurrent_add_and_remove_interleaved() {
     "-x $c"
   )
 
-  printf '%s\n' "${ops[@]}" | xargs_P 4 \
+  printf '%s\n' "${ops[@]}" | ( xargs_P 4 \
     env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
-      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz {} > /dev/null 2>&1"
+      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz {} > /dev/null 2>&1" )
 
   # 1. Datafile is non-empty and every line is well-formed.
   [[ -s $ZSHZ_DATA ]] || fail "datafile is empty after ${#ops} operations"

--- a/tests/test_concurrent_mixed.zsh
+++ b/tests/test_concurrent_mixed.zsh
@@ -41,7 +41,7 @@ test_concurrent_add_and_remove_interleaved() {
     "-x $c"
   )
 
-  printf '%s\n' "${ops[@]}" | xargs -P 4 -I {} \
+  printf '%s\n' "${ops[@]}" | xargs_P 4 \
     env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
       "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz {} > /dev/null 2>&1"
 

--- a/tests/test_config_errors.zsh
+++ b/tests/test_config_errors.zsh
@@ -1,0 +1,85 @@
+# Plugin config errors must `return', not `exit'.
+#
+# Covers commit 1747969 ("Avoid exiting the shell on plugin config
+# errors"). Three error paths -- (a) the `is-at-least 4.3.11' check at
+# the top of the file, (b) a bare-filename ZSHZ_DATA, (c) ZSHZ_DATA
+# pointing at a directory -- must all surface their error message and
+# bail without taking the user's interactive shell down with them.
+#
+# `test_datafile.zsh' already covers (b) and (c) by checking that
+# `zshz -l && print SENTINEL' doesn't print SENTINEL -- but that
+# assertion can't distinguish "zshz returned non-zero" from "the whole
+# shell exited," because both produce the same observable. The tests
+# below probe the stronger property: a sentinel placed *after* the
+# failing call must still print, which only happens if the calling
+# shell stayed alive.
+
+# Same self-locator used in test_emulate.zsh / test_strict_options.zsh.
+_zshz_test_zsh_bin() {
+  local bin
+  bin=$(readlink /proc/$$/exe 2>/dev/null)
+  [[ -x $bin ]] && { print -- $bin; return }
+  print -- ${commands[zsh]:-zsh}
+}
+
+test_old_zsh_version_check_returns_does_not_exit() {
+  # Shim `is-at-least' to return false, so the version-check branch
+  # fires. `autoload' is also shimmed to a no-op so the plugin's
+  # `autoload -Uz is-at-least' line doesn't replace our shim with an
+  # autoload stub before the check runs. The plugin's
+  # `return 1 2>/dev/null || exit 1' should hit the `return' branch
+  # (we're being sourced) and the calling shell must continue past
+  # the source.
+  local zsh_bin out
+  zsh_bin=$(_zshz_test_zsh_bin)
+
+  out=$("$zsh_bin" --no-rcs -c "
+    autoload() { : }
+    is-at-least() { return 1 }
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    print POST_SOURCE_SENTINEL
+  " 2>&1)
+
+  assert_contains "Zsh-z requires" "$out" \
+    "version-check failure should print the user-facing error"
+  assert_contains "POST_SOURCE_SENTINEL" "$out" \
+    "calling shell should survive a version-check failure"
+}
+
+test_bare_ZSHZ_DATA_returns_does_not_exit() {
+  # ZSHZ_DATA without a directory component must fail zshz cleanly,
+  # leaving the calling shell intact.
+  local zsh_bin out
+  zsh_bin=$(_zshz_test_zsh_bin)
+
+  out=$("$zsh_bin" --no-rcs -c "
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    ZSHZ_DATA=barefile zshz -l
+    print POST_BARE_SENTINEL
+  " 2>&1)
+
+  assert_contains "barefile" "$out" \
+    "bare-filename ZSHZ_DATA should produce the user-facing error"
+  assert_contains "POST_BARE_SENTINEL" "$out" \
+    "calling shell should survive a bare-filename ZSHZ_DATA"
+}
+
+test_directory_ZSHZ_DATA_returns_does_not_exit() {
+  # ZSHZ_DATA pointing at a directory must fail zshz cleanly, leaving
+  # the calling shell intact.
+  local zsh_bin out
+  zsh_bin=$(_zshz_test_zsh_bin)
+  mkdir -p "$TESTDIR/data-dir"
+
+  out=$("$zsh_bin" --no-rcs -c "
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    ZSHZ_DATA='$TESTDIR/data-dir' zshz -l
+    print POST_DIR_SENTINEL
+  " 2>&1)
+
+  assert_contains "is a directory" "$out" \
+    "directory ZSHZ_DATA should produce the user-facing error"
+  assert_contains "POST_DIR_SENTINEL" "$out" \
+    "calling shell should survive a directory ZSHZ_DATA"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_datafile.zsh
+++ b/tests/test_datafile.zsh
@@ -1,8 +1,8 @@
 # Datafile robustness: malformed lines, empty file, missing file.
 #
-# zsh-z.plugin.zsh:194 filters lines through a glob that requires
-# /path|digits[.digits]|digits format. Anything else should be silently
-# discarded, not crash zshz or pollute results.
+# When `zshz` loads the database, it filters entries down to the expected
+# `/path|rank|time` shape. Malformed lines should be ignored quietly rather
+# than crashing or polluting results.
 
 test_malformed_lines_are_filtered() {
   mkdir -p "$TESTDIR/valid"

--- a/tests/test_datafile.zsh
+++ b/tests/test_datafile.zsh
@@ -46,12 +46,10 @@ test_missing_datafile_is_created() {
 }
 
 test_ZSHZ_DATA_without_directory_prints_error_and_exits() {
-  local out
-  out=$(zsh --no-rcs -c "
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell '
     ZSHZ_DATA=barefile zshz -l
     print SENTINEL
-  " 2>&1)
+  ' 2>&1)
 
   assert_contains "ERROR: You configured a custom Zsh-z datafile (barefile), but have not specified its directory." "$out" "bare filename should be rejected"
   assert_not_contains "SENTINEL" "$out" "shell should exit before reaching later commands"
@@ -59,9 +57,7 @@ test_ZSHZ_DATA_without_directory_prints_error_and_exits() {
 
 test_ZSHZ_DATA_directory_prints_error_and_exits() {
   mkdir -p "$TESTDIR/data-dir"
-  local out
-  out=$(zsh --no-rcs -c "
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     ZSHZ_DATA='$TESTDIR/data-dir' zshz -l
     print SENTINEL
   " 2>&1)

--- a/tests/test_datafile.zsh
+++ b/tests/test_datafile.zsh
@@ -80,6 +80,60 @@ test_missing_datafile_is_created() {
   assert_eq "1" "$(zshz_rank_of "$TESTDIR")" "add when datafile missing should create and populate it"
 }
 
+test_list_on_missing_datafile_is_clean_and_empty() {
+  # Read-only operations on a never-created datafile must not error,
+  # write to stderr, or leave the shell in a bad state. The plugin
+  # auto-creates the datafile (and its parent directory) on every
+  # zshz invocation, so the file should exist after the call even
+  # though no entry has been added.
+  rm -f "$ZSHZ_DATA"
+  local out
+  out=$(zshz -l)
+  assert_eq "" "$out" "list on missing datafile should produce no output"
+  assert_file_exists "$ZSHZ_DATA"
+}
+
+test_search_on_missing_datafile_matches_nothing() {
+  rm -f "$ZSHZ_DATA"
+  local out
+  out=$(zshz nothingmatchesthis)
+  assert_eq "" "$out" "search on missing datafile should match nothing"
+}
+
+test_remove_on_missing_datafile_does_not_crash() {
+  # `zshz -x' on a missing datafile must not crash. It returns
+  # non-zero because there's nothing to remove, but stderr must be
+  # clean (the runner fails on any stderr).
+  rm -f "$ZSHZ_DATA"
+  zshz -x /tmp/never-added
+  return 0
+}
+
+test_list_on_zero_byte_datafile_is_clean_and_empty() {
+  : > "$ZSHZ_DATA"
+  local out
+  out=$(zshz -l)
+  assert_eq "" "$out" "list on zero-byte datafile should produce no output"
+}
+
+test_whitespace_only_datafile_is_treated_as_empty() {
+  # Newlines without any line content -- the `${(f)...}` split
+  # produces empty array elements, and the malformed-line filter
+  # discards them. --add should still work; -l should be empty.
+  printf '\n\n\n' > "$ZSHZ_DATA"
+  zshz --add "$TESTDIR" || return 1
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR")" "whitespace-only datafile should not block --add"
+}
+
+test_precmd_on_missing_datafile_creates_and_populates() {
+  rm -f "$ZSHZ_DATA"
+  mkdir -p "$TESTDIR/work"
+  cd "$TESTDIR/work"
+  _zshz_precmd
+  _wait_for_add "$TESTDIR/work"
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/work")" "precmd should create datafile and add PWD"
+}
+
 test_ZSHZ_DATA_without_directory_prints_error_and_exits() {
   local out
   out=$(zshz_in_fresh_shell '

--- a/tests/test_datafile.zsh
+++ b/tests/test_datafile.zsh
@@ -46,7 +46,8 @@ test_missing_datafile_is_created() {
 }
 
 test_ZSHZ_DATA_without_directory_prints_error_and_exits() {
-  local out=$(zshz_in_fresh_shell '
+  local out
+  out=$(zshz_in_fresh_shell '
     ZSHZ_DATA=barefile zshz -l
     print SENTINEL
   ' 2>&1)
@@ -57,7 +58,8 @@ test_ZSHZ_DATA_without_directory_prints_error_and_exits() {
 
 test_ZSHZ_DATA_directory_prints_error_and_exits() {
   mkdir -p "$TESTDIR/data-dir"
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     ZSHZ_DATA='$TESTDIR/data-dir' zshz -l
     print SENTINEL
   " 2>&1)

--- a/tests/test_datafile.zsh
+++ b/tests/test_datafile.zsh
@@ -1,0 +1,46 @@
+# Datafile robustness: malformed lines, empty file, missing file.
+#
+# zsh-z.plugin.zsh:194 filters lines through a glob that requires
+# /path|digits[.digits]|digits format. Anything else should be silently
+# discarded, not crash zshz or pollute results.
+
+test_malformed_lines_are_filtered() {
+  mkdir -p "$TESTDIR/valid"
+  cat > "$ZSHZ_DATA" <<EOF
+$TESTDIR/valid|5|1700000000
+
+random text
+$TESTDIR|nope|123
+no-leading-slash|5|1700000000
+|5|1700000000
+$TESTDIR/missingfields
+EOF
+  local out
+  out=$(zshz -l 2>&1)
+  assert_contains "$TESTDIR/valid" "$out" "well-formed entry should be listed"
+  assert_not_contains "random text" "$out" "garbage line should not appear"
+  assert_not_contains "no-leading-slash" "$out" "non-absolute path should not appear"
+  assert_not_contains "missingfields" "$out" "incomplete line should not appear"
+}
+
+test_malformed_datafile_does_not_break_add() {
+  cat > "$ZSHZ_DATA" <<EOF
+total garbage
+more garbage
+EOF
+  zshz --add "$TESTDIR" || return 1
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR")" "--add should still work despite malformed prior content"
+}
+
+test_empty_datafile() {
+  : > "$ZSHZ_DATA"
+  zshz --add "$TESTDIR" || return 1
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR")" "add to empty datafile should create the entry"
+}
+
+test_missing_datafile_is_created() {
+  rm -f "$ZSHZ_DATA"
+  zshz --add "$TESTDIR" || return 1
+  assert_file_exists "$ZSHZ_DATA"
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR")" "add when datafile missing should create and populate it"
+}

--- a/tests/test_datafile.zsh
+++ b/tests/test_datafile.zsh
@@ -44,3 +44,28 @@ test_missing_datafile_is_created() {
   assert_file_exists "$ZSHZ_DATA"
   assert_eq "1" "$(zshz_rank_of "$TESTDIR")" "add when datafile missing should create and populate it"
 }
+
+test_ZSHZ_DATA_without_directory_prints_error_and_exits() {
+  local out
+  out=$(zsh --no-rcs -c "
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    ZSHZ_DATA=barefile zshz -l
+    print SENTINEL
+  " 2>&1)
+
+  assert_contains "ERROR: You configured a custom Zsh-z datafile (barefile), but have not specified its directory." "$out" "bare filename should be rejected"
+  assert_not_contains "SENTINEL" "$out" "shell should exit before reaching later commands"
+}
+
+test_ZSHZ_DATA_directory_prints_error_and_exits() {
+  mkdir -p "$TESTDIR/data-dir"
+  local out
+  out=$(zsh --no-rcs -c "
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    ZSHZ_DATA='$TESTDIR/data-dir' zshz -l
+    print SENTINEL
+  " 2>&1)
+
+  assert_contains "ERROR: Zsh-z's datafile ($TESTDIR/data-dir) is a directory." "$out" "directory datafile should be rejected"
+  assert_not_contains "SENTINEL" "$out" "shell should exit before reaching later commands"
+}

--- a/tests/test_datafile.zsh
+++ b/tests/test_datafile.zsh
@@ -6,21 +6,56 @@
 
 test_malformed_lines_are_filtered() {
   mkdir -p "$TESTDIR/valid"
-  cat > "$ZSHZ_DATA" <<EOF
-$TESTDIR/valid|5|1700000000
+  # The embedded-newline case (printf %b on \n) ends up as two physical
+  # lines after `${(f)...}` splitting: `$TESTDIR/embed` and `inner|9|123'.
+  # Both should be rejected by the filter -- the first because it has no
+  # `|rank|time' suffix, the second because it has no leading `/'.
+  printf '%b' "$TESTDIR/valid|5|1700000000
 
 random text
 $TESTDIR|nope|123
 no-leading-slash|5|1700000000
 |5|1700000000
 $TESTDIR/missingfields
-EOF
+$TESTDIR/trailing|5|1700000000|extra
+$TESTDIR/embed\ninner|9|123
+" > "$ZSHZ_DATA"
   local out
   out=$(zshz -l 2>&1)
   assert_contains "$TESTDIR/valid" "$out" "well-formed entry should be listed"
   assert_not_contains "random text" "$out" "garbage line should not appear"
   assert_not_contains "no-leading-slash" "$out" "non-absolute path should not appear"
   assert_not_contains "missingfields" "$out" "incomplete line should not appear"
+  assert_not_contains "trailing" "$out" "line with extra trailing fields should not appear"
+  assert_not_contains "embed" "$out" "fragments split by an embedded newline should not appear"
+  assert_not_contains "inner" "$out" "fragments split by an embedded newline should not appear"
+}
+
+test_add_preserves_valid_entries_amid_malformed_ones() {
+  mkdir -p "$TESTDIR/valid" "$TESTDIR/new"
+  printf '%b' "$TESTDIR/valid|5|1700000000
+
+random text
+$TESTDIR|nope|123
+$TESTDIR/trailing|5|1700000000|extra
+$TESTDIR/embed\ninner|9|123
+" > "$ZSHZ_DATA"
+
+  zshz --add "$TESTDIR/new" || return 1
+
+  # The newly-added entry must land...
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/new")" "--add should land despite malformed neighbors"
+  # ...and the valid entry must survive the rewrite. The pre-existing
+  # rank was 5; --add bumps existing entries by 1 only when the same
+  # path is re-added, so the survivor's rank should still be 5.
+  assert_eq "5" "$(zshz_rank_of "$TESTDIR/valid")" "valid entry should survive a rewrite past malformed lines"
+
+  # Garbage lines should be gone from the datafile after the rewrite.
+  local dump
+  dump=$(zshz_dump)
+  assert_not_contains "random text" "$dump" "garbage line should be dropped on rewrite"
+  assert_not_contains "trailing" "$dump" "trailing-junk line should be dropped on rewrite"
+  assert_not_contains "embed" "$dump" "embedded-newline fragment should be dropped on rewrite"
 }
 
 test_malformed_datafile_does_not_break_add() {

--- a/tests/test_datafile.zsh
+++ b/tests/test_datafile.zsh
@@ -55,6 +55,7 @@ test_ZSHZ_DATA_without_directory_prints_error_and_exits() {
   assert_contains "ERROR: You configured a custom Zsh-z datafile (barefile), but have not specified its directory." "$out" "bare filename should be rejected"
   assert_not_contains "SENTINEL" "$out" "shell should exit before reaching later commands"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:
 
 test_ZSHZ_DATA_directory_prints_error_and_exits() {
   mkdir -p "$TESTDIR/data-dir"

--- a/tests/test_datafile.zsh
+++ b/tests/test_datafile.zsh
@@ -48,12 +48,11 @@ test_missing_datafile_is_created() {
 test_ZSHZ_DATA_without_directory_prints_error_and_exits() {
   local out
   out=$(zshz_in_fresh_shell '
-    ZSHZ_DATA=barefile zshz -l
-    print SENTINEL
+    ZSHZ_DATA=barefile zshz -l && print SENTINEL
   ' 2>&1)
 
   assert_contains "ERROR: You configured a custom Zsh-z datafile (barefile), but have not specified its directory." "$out" "bare filename should be rejected"
-  assert_not_contains "SENTINEL" "$out" "shell should exit before reaching later commands"
+  assert_not_contains "SENTINEL" "$out" "zshz should return non-zero on misconfigured datafile"
 }
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:
 
@@ -61,10 +60,9 @@ test_ZSHZ_DATA_directory_prints_error_and_exits() {
   mkdir -p "$TESTDIR/data-dir"
   local out
   out=$(zshz_in_fresh_shell "
-    ZSHZ_DATA='$TESTDIR/data-dir' zshz -l
-    print SENTINEL
+    ZSHZ_DATA='$TESTDIR/data-dir' zshz -l && print SENTINEL
   " 2>&1)
 
   assert_contains "ERROR: Zsh-z's datafile ($TESTDIR/data-dir) is a directory." "$out" "directory datafile should be rejected"
-  assert_not_contains "SENTINEL" "$out" "shell should exit before reaching later commands"
+  assert_not_contains "SENTINEL" "$out" "zshz should return non-zero on misconfigured datafile"
 }

--- a/tests/test_echo.zsh
+++ b/tests/test_echo.zsh
@@ -3,7 +3,8 @@
 test_echo_off_no_print_on_jump() {
   mkdir -p "$TESTDIR/foo"
   zshz --add "$TESTDIR/foo"
-  local out=$(zshz foo)
+  local out
+  out=$(zshz foo)
   assert_eq "" "$out" "without ZSHZ_ECHO, jump should produce no output"
 }
 
@@ -11,7 +12,8 @@ test_echo_prints_destination_path() {
   mkdir -p "$TESTDIR/foo"
   zshz --add "$TESTDIR/foo"
   ZSHZ_ECHO=1
-  local out=$(zshz foo)
+  local out
+  out=$(zshz foo)
   assert_eq "$TESTDIR/foo" "$out" "ZSHZ_ECHO=1 should print path after jump"
 }
 
@@ -21,6 +23,7 @@ test_echo_combined_with_tilde() {
   zshz --add "$HOME/foo"
   ZSHZ_ECHO=1
   ZSHZ_TILDE=1
-  local out=$(zshz foo)
+  local out
+  out=$(zshz foo)
   assert_eq "~/foo" "$out" "ECHO + TILDE should print ~ form"
 }

--- a/tests/test_echo.zsh
+++ b/tests/test_echo.zsh
@@ -27,3 +27,4 @@ test_echo_combined_with_tilde() {
   out=$(zshz foo)
   assert_eq "~/foo" "$out" "ECHO + TILDE should print ~ form"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_echo.zsh
+++ b/tests/test_echo.zsh
@@ -1,0 +1,26 @@
+# ZSHZ_ECHO: print the destination path after a successful jump.
+
+test_echo_off_no_print_on_jump() {
+  mkdir -p "$TESTDIR/foo"
+  zshz --add "$TESTDIR/foo"
+  local out=$(zshz foo)
+  assert_eq "" "$out" "without ZSHZ_ECHO, jump should produce no output"
+}
+
+test_echo_prints_destination_path() {
+  mkdir -p "$TESTDIR/foo"
+  zshz --add "$TESTDIR/foo"
+  ZSHZ_ECHO=1
+  local out=$(zshz foo)
+  assert_eq "$TESTDIR/foo" "$out" "ZSHZ_ECHO=1 should print path after jump"
+}
+
+test_echo_combined_with_tilde() {
+  local HOME="$TESTDIR"
+  mkdir -p "$HOME/foo"
+  zshz --add "$HOME/foo"
+  ZSHZ_ECHO=1
+  ZSHZ_TILDE=1
+  local out=$(zshz foo)
+  assert_eq "~/foo" "$out" "ECHO + TILDE should print ~ form"
+}

--- a/tests/test_emulate.zsh
+++ b/tests/test_emulate.zsh
@@ -1,0 +1,86 @@
+# Sourcing under non-zsh emulation modes (emulate sh / bash / ksh).
+#
+# zsh-z uses Zsh-only syntax in function bodies (extended-glob `##'
+# quantifiers, `(M)' and `(@)' parameter-expansion flags, etc.). Those
+# constructs fail to parse when the calling shell is in sh/bash/ksh
+# emulation -- and many users have `emulate sh' or `emulate bash' in
+# their .zshrc.
+#
+# The plugin's gate at the top of zsh-z.plugin.zsh detects non-zsh
+# emulation via `[[ -o KSH_ARRAYS || -o SH_WORD_SPLIT ]]' and
+# re-sources itself under `emulate zsh -c' so the body parses
+# correctly. The gate uses `${(%):-%N}' for the script's own path
+# because `$0' is the shell binary under emulate sh, not the sourced
+# file.
+#
+# Each test below spawns a fresh child shell, switches to the target
+# emulation, sources the plugin, then exercises a basic --add/-l
+# round-trip. Linux-only via /proc/$$/exe (existing concurrency tests
+# already assume this).
+
+# Pick the same zsh binary the test runner is using, falling back to
+# whatever is in PATH.
+_zshz_test_zsh_bin() {
+  local bin
+  bin=$(readlink /proc/$$/exe 2>/dev/null)
+  [[ -x $bin ]] && { print -- $bin; return }
+  print -- ${commands[zsh]:-zsh}
+}
+
+_zshz_test_emulate_round_trip() {
+  local mode=$1 zsh_bin
+  zsh_bin=$(_zshz_test_zsh_bin)
+  mkdir -p "$TESTDIR/work"
+
+  local out
+  out=$("$zsh_bin" --no-rcs -c "
+    $mode
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zshz --add '$TESTDIR/work'
+    zshz -l
+  " 2>&1)
+  local rc=$?
+
+  assert_eq "0" "$rc" "$mode: source + add + list should succeed (output: $out)"
+  assert_contains "$TESTDIR/work" "$out" \
+    "$mode: list output should contain the added path"
+}
+
+test_source_under_emulate_sh() {
+  _zshz_test_emulate_round_trip 'emulate sh'
+}
+
+test_source_under_emulate_sh_R() {
+  _zshz_test_emulate_round_trip 'emulate sh -R'
+}
+
+test_source_under_emulate_bash() {
+  _zshz_test_emulate_round_trip 'emulate bash'
+}
+
+test_source_under_emulate_ksh() {
+  _zshz_test_emulate_round_trip 'emulate ksh'
+}
+
+test_emulate_gate_does_not_fire_under_pure_zsh() {
+  # Under pure zsh the gate's option check should be false and the
+  # plugin should source directly without recursing through
+  # `emulate zsh -c "source ..."'. Verify by: (a) sourcing succeeds,
+  # and (b) `zshz --add' lands an entry as usual.
+  local zsh_bin
+  zsh_bin=$(_zshz_test_zsh_bin)
+  mkdir -p "$TESTDIR/work"
+
+  local out
+  out=$("$zsh_bin" --no-rcs -c "
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zshz --add '$TESTDIR/work'
+    zshz -l
+  " 2>&1)
+  local rc=$?
+
+  assert_eq "0" "$rc" "pure zsh: round-trip should succeed (output: $out)"
+  assert_contains "$TESTDIR/work" "$out" \
+    "pure zsh: list output should contain the added path"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_external_writer.zsh
+++ b/tests/test_external_writer.zsh
@@ -1,0 +1,76 @@
+# Concurrent writers must serialize cleanly under develop's lockfile
+# design: an external writer running between our read and our `mv'
+# must not cause a pre-existing entry to be lost, and both writers'
+# new adds must land.
+#
+# Develop reads the datafile *after* taking the lock (separate stable
+# `${datafile}.lock'); master read it before, so two writers could
+# each compute a tempfile based on a stale snapshot and the second
+# `mv' would silently drop the first writer's update -- including any
+# pre-existing entries that were only present in the first writer's
+# computed result. The pre-seed in this test is what distinguishes it
+# from `test_concurrent_add_two_paths_each_independent', which only
+# pins that the two new adds land.
+#
+# This test deliberately commits to develop's lockfile semantics. The
+# `optimistic_concurrency' branch would cleanly drop one of the two
+# new adds, and the assertions below would fail; that's intentional.
+
+test_external_writer_during_our_add_serializes() {
+  local seeded="$TESTDIR/seeded" a="$TESTDIR/a" b="$TESTDIR/b"
+  mkdir -p "$seeded" "$a" "$b"
+
+  # Pre-seed an entry. Under master's broken read-before-lock, this
+  # could be lost when two writers race; under develop, it must
+  # survive at exactly its seeded rank (neither writer is touching
+  # this path).
+  zshz_seed "$seeded" 5 60
+
+  # Two writers race for the lockfile. xargs -P 2 spawns them as
+  # external `zsh -c' processes (avoids zsh 4.3.11's `&'/`wait'
+  # segfault under fork load). The high lock timeout keeps honest
+  # contention from being mistaken for a regression.
+  printf '%s\n' "$a" "$b" | xargs -P 2 -I {} \
+    env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
+      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add {}"
+
+  assert_eq "5" "$(zshz_rank_of "$seeded")" \
+    "pre-seeded entry should survive two concurrent --add writers"
+  assert_eq "1" "$(zshz_rank_of "$a")" \
+    "first concurrent --add should land"
+  assert_eq "1" "$(zshz_rank_of "$b")" \
+    "second concurrent --add should land"
+}
+
+test_many_concurrent_writers_preserve_seeded_entries() {
+  # Stronger version of the above: a fleet of writers, each adding a
+  # unique path, must not drop any of the N pre-seeded entries.
+  # `_zshz_update_datafile' rebuilds the datafile from `lines' on
+  # every write, so a stale `lines' (master's bug) would silently
+  # delete entries that another in-flight writer just added. With
+  # develop's read-after-lock, every writer sees the latest state.
+  local seeded_count=10 writer_count=10 i
+  local -a writer_paths
+  for ((i=1; i<=seeded_count; i++)); do
+    mkdir -p "$TESTDIR/seed_$i"
+    zshz_seed "$TESTDIR/seed_$i" $i 60
+  done
+  for ((i=1; i<=writer_count; i++)); do
+    mkdir -p "$TESTDIR/w_$i"
+    writer_paths+=( "$TESTDIR/w_$i" )
+  done
+
+  printf '%s\n' "${writer_paths[@]}" | xargs -P 4 -I {} \
+    env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
+      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add {}"
+
+  for ((i=1; i<=seeded_count; i++)); do
+    assert_eq "$i" "$(zshz_rank_of "$TESTDIR/seed_$i")" \
+      "seeded entry $i must survive $writer_count concurrent writers"
+  done
+  for ((i=1; i<=writer_count; i++)); do
+    assert_eq "1" "$(zshz_rank_of "$TESTDIR/w_$i")" \
+      "writer $i's --add must have landed"
+  done
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_external_writer.zsh
+++ b/tests/test_external_writer.zsh
@@ -17,6 +17,13 @@
 # new adds, and the assertions below would fail; that's intentional.
 
 test_external_writer_during_our_add_serializes() {
+  # Without `zsystem flock', the no-lock fallback can't serialize
+  # cross-process writers and the second `mv' overwrites the first.
+  # Skip when the system module is unavailable (e.g. MobaXterm's Cygwin).
+  if ! (( ZSHZ[USE_FLOCK] )); then
+    print "skip: zsystem flock unavailable"
+    return 0
+  fi
   local seeded="$TESTDIR/seeded" a="$TESTDIR/a" b="$TESTDIR/b"
   mkdir -p "$seeded" "$a" "$b"
 
@@ -49,6 +56,10 @@ test_many_concurrent_writers_preserve_seeded_entries() {
   # every write, so a stale `lines' (master's bug) would silently
   # delete entries that another in-flight writer just added. With
   # develop's read-after-lock, every writer sees the latest state.
+  if ! (( ZSHZ[USE_FLOCK] )); then
+    print "skip: zsystem flock unavailable"
+    return 0
+  fi
   local seeded_count=10 writer_count=10 i
   local -a writer_paths
   for ((i=1; i<=seeded_count; i++)); do

--- a/tests/test_external_writer.zsh
+++ b/tests/test_external_writer.zsh
@@ -30,7 +30,7 @@ test_external_writer_during_our_add_serializes() {
   # external `zsh -c' processes (avoids zsh 4.3.11's `&'/`wait'
   # segfault under fork load). The high lock timeout keeps honest
   # contention from being mistaken for a regression.
-  printf '%s\n' "$a" "$b" | xargs -P 2 -I {} \
+  printf '%s\n' "$a" "$b" | xargs_P 2 \
     env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
       "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add {}"
 
@@ -60,7 +60,7 @@ test_many_concurrent_writers_preserve_seeded_entries() {
     writer_paths+=( "$TESTDIR/w_$i" )
   done
 
-  printf '%s\n' "${writer_paths[@]}" | xargs -P 4 -I {} \
+  printf '%s\n' "${writer_paths[@]}" | xargs_P 4 \
     env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
       "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add {}"
 

--- a/tests/test_external_writer.zsh
+++ b/tests/test_external_writer.zsh
@@ -30,9 +30,9 @@ test_external_writer_during_our_add_serializes() {
   # external `zsh -c' processes (avoids zsh 4.3.11's `&'/`wait'
   # segfault under fork load). The high lock timeout keeps honest
   # contention from being mistaken for a regression.
-  printf '%s\n' "$a" "$b" | xargs_P 2 \
+  printf '%s\n' "$a" "$b" | ( xargs_P 2 \
     env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
-      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add {}"
+      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add {}" )
 
   assert_eq "5" "$(zshz_rank_of "$seeded")" \
     "pre-seeded entry should survive two concurrent --add writers"
@@ -60,9 +60,9 @@ test_many_concurrent_writers_preserve_seeded_entries() {
     writer_paths+=( "$TESTDIR/w_$i" )
   done
 
-  printf '%s\n' "${writer_paths[@]}" | xargs_P 4 \
+  printf '%s\n' "${writer_paths[@]}" | ( xargs_P 4 \
     env ZSHZ_LOCK_TIMEOUT=30 zsh -c \
-      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add {}"
+      "source '$PLUGIN_DIR/zsh-z.plugin.zsh'; zshz --add {}" )
 
   for ((i=1; i<=seeded_count; i++)); do
     assert_eq "$i" "$(zshz_rank_of "$TESTDIR/seed_$i")" \

--- a/tests/test_fallback.zsh
+++ b/tests/test_fallback.zsh
@@ -1,0 +1,53 @@
+# Path fallback behavior when no database match exists.
+
+test_relative_path_fallback_changes_directory() {
+  mkdir -p "$TESTDIR/rel"
+  cd "$TESTDIR"
+
+  local out
+  out=$(zshz rel && pwd)
+  assert_eq "$TESTDIR/rel" "$out" "relative directory arguments should fall back to direct cd"
+}
+
+test_parent_relative_path_fallback_changes_directory() {
+  mkdir -p "$TESTDIR/base/target" "$TESTDIR/base/from"
+  cd "$TESTDIR/base/from"
+
+  local out
+  out=$(zshz ../target && pwd)
+  assert_eq "$TESTDIR/base/target" "$out" "parent-relative directory arguments should fall back to direct cd"
+}
+
+test_absolute_path_fallback_changes_directory() {
+  mkdir -p "$TESTDIR/abs"
+
+  local out
+  out=$(zshz "$TESTDIR/abs" && pwd)
+  assert_eq "$TESTDIR/abs" "$out" "absolute directory arguments should bypass the database and cd directly"
+}
+
+test_relative_path_fallback_does_not_apply_with_echo_or_list() {
+  mkdir -p "$TESTDIR/rel"
+  cd "$TESTDIR"
+
+  local out rc
+  out=$(zshz -e rel 2>/dev/null)
+  rc=$?
+  assert_ne "0" "$rc" "-e should not use direct-path fallback"
+  assert_eq "" "$out" "-e should not echo a direct-path fallback"
+
+  out=$(zshz -l rel 2>/dev/null)
+  rc=$?
+  assert_ne "0" "$rc" "-l should not use direct-path fallback"
+  assert_eq "" "$out" "-l should not list a direct-path fallback"
+}
+
+test_absolute_path_fallback_does_not_apply_with_echo() {
+  mkdir -p "$TESTDIR/abs"
+
+  local out rc
+  out=$(zshz -e "$TESTDIR/abs" 2>/dev/null)
+  rc=$?
+  assert_ne "0" "$rc" "-e should skip the absolute-path fast path"
+  assert_eq "" "$out" "-e should not echo a direct absolute-path fallback"
+}

--- a/tests/test_fallback.zsh
+++ b/tests/test_fallback.zsh
@@ -51,3 +51,4 @@ test_absolute_path_fallback_does_not_apply_with_echo() {
   assert_ne "0" "$rc" "-e should skip the absolute-path fast path"
   assert_eq "" "$out" "-e should not echo a direct absolute-path fallback"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_helpers.zsh
+++ b/tests/test_helpers.zsh
@@ -7,25 +7,37 @@ fail() {
 }
 
 assert_eq() {
-  local expected=$1 actual=$2 msg=${3:-}
+  local expected actual msg
+  expected="$1"
+  actual="$2"
+  msg="${3:-}"
   [[ $expected == $actual ]] && return 0
   fail "${msg:+$msg: }expected '$expected', got '$actual'"
 }
 
 assert_ne() {
-  local unexpected=$1 actual=$2 msg=${3:-}
+  local unexpected actual msg
+  unexpected="$1"
+  actual="$2"
+  msg="${3:-}"
   [[ $unexpected != $actual ]] && return 0
   fail "${msg:+$msg: }expected anything but '$unexpected', got '$actual'"
 }
 
 assert_contains() {
-  local needle=$1 haystack=$2 msg=${3:-}
+  local needle haystack msg
+  needle="$1"
+  haystack="$2"
+  msg="${3:-}"
   [[ $haystack == *$needle* ]] && return 0
   fail "${msg:+$msg: }expected '$haystack' to contain '$needle'"
 }
 
 assert_not_contains() {
-  local needle=$1 haystack=$2 msg=${3:-}
+  local needle haystack msg
+  needle="$1"
+  haystack="$2"
+  msg="${3:-}"
   [[ $haystack != *$needle* ]] && return 0
   fail "${msg:+$msg: }expected '$haystack' not to contain '$needle'"
 }
@@ -49,7 +61,10 @@ zshz_dump() {
 
 # Append a synthetic entry to $ZSHZ_DATA with timestamp = now - SECONDS_AGO.
 zshz_seed() {
-  local path=$1 rank=$2 seconds_ago=${3:-0}
+  local path rank seconds_ago
+  path="$1"
+  rank="$2"
+  seconds_ago="${3:-0}"
   print "${path}|${rank}|$(( EPOCHSECONDS - seconds_ago ))" >> "$ZSHZ_DATA"
 }
 

--- a/tests/test_helpers.zsh
+++ b/tests/test_helpers.zsh
@@ -1,0 +1,48 @@
+# Test helpers for Zsh-z. Sourced by tests/run.zsh and by each test_*.zsh.
+
+# Fail with a message
+fail() {
+  print -u 2 "  $*"
+  return 1
+}
+
+assert_eq() {
+  local expected=$1 actual=$2 msg=${3:-}
+  [[ $expected == $actual ]] && return 0
+  fail "${msg:+$msg: }expected '$expected', got '$actual'"
+}
+
+assert_ne() {
+  local unexpected=$1 actual=$2 msg=${3:-}
+  [[ $unexpected != $actual ]] && return 0
+  fail "${msg:+$msg: }expected anything but '$unexpected', got '$actual'"
+}
+
+assert_contains() {
+  local needle=$1 haystack=$2 msg=${3:-}
+  [[ $haystack == *$needle* ]] && return 0
+  fail "${msg:+$msg: }expected '$haystack' to contain '$needle'"
+}
+
+assert_not_contains() {
+  local needle=$1 haystack=$2 msg=${3:-}
+  [[ $haystack != *$needle* ]] && return 0
+  fail "${msg:+$msg: }expected '$haystack' not to contain '$needle'"
+}
+
+assert_file_exists() {
+  [[ -f $1 ]] && return 0
+  fail "expected file '$1' to exist"
+}
+
+# Read the rank for $1 from the current $ZSHZ_DATA
+zshz_rank_of() {
+  local p=$1
+  [[ -f $ZSHZ_DATA ]] || { print ""; return; }
+  awk -F'|' -v p="$p" '$1==p { print $2 }' "$ZSHZ_DATA"
+}
+
+# Read the entire datafile, sorted by path, for stable comparisons
+zshz_dump() {
+  [[ -f $ZSHZ_DATA ]] && sort "$ZSHZ_DATA"
+}

--- a/tests/test_helpers.zsh
+++ b/tests/test_helpers.zsh
@@ -11,7 +11,7 @@ assert_eq() {
   expected="$1"
   actual="$2"
   msg="${3:-}"
-  [[ $expected == $actual ]] && return 0
+  [[ $expected == "$actual" ]] && return 0
   fail "${msg:+$msg: }expected '$expected', got '$actual'"
 }
 
@@ -20,7 +20,7 @@ assert_ne() {
   unexpected="$1"
   actual="$2"
   msg="${3:-}"
-  [[ $unexpected != $actual ]] && return 0
+  [[ $unexpected != "$actual" ]] && return 0
   fail "${msg:+$msg: }expected anything but '$unexpected', got '$actual'"
 }
 

--- a/tests/test_helpers.zsh
+++ b/tests/test_helpers.zsh
@@ -46,3 +46,21 @@ zshz_rank_of() {
 zshz_dump() {
   [[ -f $ZSHZ_DATA ]] && sort "$ZSHZ_DATA"
 }
+
+# Append a synthetic entry to $ZSHZ_DATA with timestamp = now - SECONDS_AGO.
+zshz_seed() {
+  local path=$1 rank=$2 seconds_ago=${3:-0}
+  print "${path}|${rank}|$(( EPOCHSECONDS - seconds_ago ))" >> "$ZSHZ_DATA"
+}
+
+# Run BODY in a fresh `zsh --no-rcs -c` after binding Tab to expand-or-complete
+# and sourcing the plugin. Tests that need different setup before sourcing
+# (e.g. _Z_CMD=zoo, or a non-default Tab binding as captured baseline) must
+# use raw `zsh -c`.
+zshz_in_fresh_shell() {
+  zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    $1
+  "
+}

--- a/tests/test_helpers.zsh
+++ b/tests/test_helpers.zsh
@@ -79,3 +79,4 @@ zshz_in_fresh_shell() {
     $1
   "
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_helpers.zsh
+++ b/tests/test_helpers.zsh
@@ -68,6 +68,48 @@ zshz_seed() {
   print "${path}|${rank}|$(( EPOCHSECONDS - seconds_ago ))" >> "$ZSHZ_DATA"
 }
 
+# Drop-in replacement for `xargs -P NPROC -I {} CMD ARGS...'.
+#
+# Solaris (and other AT&T-derived) `xargs' don't support `-P'. Where the
+# system `xargs' has it, we use it -- the concurrency tests rely on
+# spawning external `zsh -c' processes to dodge zsh 4.3.11's `&'/`wait'
+# segfault under fork load. Where `-P' isn't available (Solaris with a
+# modern zsh), `&'+`wait' works and we fall back to that. The probe
+# result is cached in `_XARGS_P_OK'.
+#
+# NPROC is honored only on the `xargs -P' path; the fallback spawns
+# every item at once -- fine for the small N (<=30) the suite uses.
+xargs_P() {
+  local nproc=$1; shift
+  if _xargs_supports_P; then
+    xargs -P "$nproc" -I {} "$@"
+    return
+  fi
+  local line a
+  local -a pids cmd
+  while IFS= read -r line; do
+    cmd=()
+    for a in "$@"; do
+      cmd+=( "${a//\{\}/$line}" )
+    done
+    "${cmd[@]}" &
+    pids+=( $! )
+  done
+  (( ${#pids} )) && wait "${pids[@]}" 2>/dev/null
+}
+
+_xargs_supports_P() {
+  if [[ -z ${_XARGS_P_OK+set} ]]; then
+    typeset -gi _XARGS_P_OK
+    if : | xargs -P 1 -I {} true 2>/dev/null; then
+      _XARGS_P_OK=1
+    else
+      _XARGS_P_OK=0
+    fi
+  fi
+  (( _XARGS_P_OK ))
+}
+
 # Run BODY in a fresh `zsh --no-rcs -c` after binding Tab to expand-or-complete
 # and sourcing the plugin. Tests that need different setup before sourcing
 # (e.g. _Z_CMD=zoo, or a non-default Tab binding as captured baseline) must

--- a/tests/test_helpers.zsh
+++ b/tests/test_helpers.zsh
@@ -79,11 +79,18 @@ zshz_seed() {
 #
 # NPROC is honored only on the `xargs -P' path; the fallback spawns
 # every item at once -- fine for the small N (<=30) the suite uses.
+#
+# IMPORTANT: callers must invoke this inside `( ... )' on the right side
+# of a pipe, e.g. `producer | ( xargs_P 4 cmd args )'. Two reasons:
+# (1) zsh does NOT fork the right side of a pipe when it's a function or
+# block, so without the parens the `exec' below would replace the
+# caller's shell.  (2) On zsh 4.3.11, an internal `( ... )' inside a
+# function-on-pipe-right triggers SIGBUS at higher fork counts -- the
+# parens have to be at the call site, not in the function body.
 xargs_P() {
   local nproc=$1; shift
   if _xargs_supports_P; then
-    xargs -P "$nproc" -I {} "$@"
-    return
+    exec xargs -P "$nproc" -I {} "$@"
   fi
   local line a
   local -a pids cmd
@@ -100,11 +107,13 @@ xargs_P() {
 
 _xargs_supports_P() {
   if [[ -z ${_XARGS_P_OK+set} ]]; then
-    typeset -gi _XARGS_P_OK
-    if : | xargs -P 1 -I {} true 2>/dev/null; then
-      _XARGS_P_OK=1
+    # `< /dev/null' rather than `: | xargs ...': fewer forks per probe,
+    # which matters on zsh 4.3.11 where the fork machinery is fragile.
+    # `-gx' exports the cache so test subshells skip the re-probe.
+    if xargs -P 1 -I {} true < /dev/null 2>/dev/null; then
+      typeset -gx _XARGS_P_OK=1
     else
-      _XARGS_P_OK=0
+      typeset -gx _XARGS_P_OK=0
     fi
   fi
   (( _XARGS_P_OK ))

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -141,4 +141,70 @@ test_precmd_does_not_emit_done_line_in_interactive_shell() {
     fail "backgrounded write never landed (rank=$rank)"
   fi
 }
+
+test_repeated_precmd_under_prompt_spam() {
+  # Hammer `_zshz_precmd' in a tight loop and verify:
+  #   1. The calling shell holds no lockfile fd afterward. In the
+  #      current async precmd, lock acquisition happens inside the
+  #      disowned `zshz --add' child's own fd table -- the parent
+  #      should never end up holding one. This guards against a future
+  #      refactor that makes precmd synchronous without preserving the
+  #      `always { ... zsystem flock -u }' discipline in
+  #      `_zshz_add_or_remove_path'.
+  #   2. Several disowned writes actually land in the datafile.
+  #
+  # N is modest because zsh 4.3.11's `&'/`wait' machinery segfaults
+  # under heavier fork load (see test_concurrency.zsh's note about
+  # spawning external `zsh -c' processes). The
+  # `test_lock_fd_does_not_leak_across_repeated_adds' regression
+  # covers the synchronous-`--add' fd-leak path with an external probe;
+  # this test complements it on the precmd path.
+  [[ -d /proc/self/fd ]] || { print "skip: /proc/self/fd unavailable"; return 0; }
+
+  mkdir -p "$TESTDIR/work"
+  cd "$TESTDIR/work"
+
+  local i n=30
+  for ((i=0; i<n; i++)); do
+    _zshz_precmd
+  done
+
+  # Drain: wait until the rank stops growing for one tick.
+  local deadline=$(( EPOCHSECONDS + 6 ))
+  local prev=-1 cur=
+  while (( EPOCHSECONDS < deadline )); do
+    cur=$(zshz_rank_of "$TESTDIR/work")
+    [[ -n $cur && $cur == $prev ]] && break
+    prev=${cur:-0}
+    sleep 0.1
+  done
+
+  # Inspect this shell's own fd table via /proc/self/fd. We resolve the
+  # symlink targets via zsh's `:A' modifier rather than external
+  # `readlink' / `lsof', because `zsystem flock' opens its lockfd with
+  # FD_CLOEXEC -- a forked `readlink' would see those fds as already
+  # closed and miss the leak entirely. `$$' is the wrong pid here too:
+  # in zsh `$$' refers to the parent shell, not the subshell that ran
+  # `_zshz_precmd', so anything spawning a child to inspect "this
+  # shell's" fds would also miss the target process.
+  local fd link
+  local -a leaks
+  local lockname=${ZSHZ_DATA##*/}.lock
+  for fd in /proc/self/fd/*(N); do
+    link=${fd:A}
+    [[ $link == *$lockname* ]] && leaks+=( "$fd -> $link" )
+  done
+  if (( ${#leaks} )); then
+    fail "calling shell holds lockfile fds: ${(j:; :)leaks}"
+  fi
+
+  # And several disowned writes must have landed. We don't expect rank
+  # == n: the children all race for the lockfile, and ZSHZ_LOCK_TIMEOUT
+  # may legitimately drop a few. We expect a clear majority though.
+  local rank
+  rank=$(zshz_rank_of "$TESTDIR/work")
+  if [[ -z $rank ]] || (( rank < 5 )); then
+    fail "expected several disowned writes to land; got rank=${rank:-(empty)}"
+  fi
+}
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -1,4 +1,8 @@
 # Hook behavior for precmd/chpwd integration.
+#
+# These tests force OSTYPE=cygwin so `_zshz_precmd` takes its foreground write
+# path; otherwise it backgrounds `zshz --add`, which would make the assertions
+# racy.
 
 test_precmd_adds_pwd_in_foreground() {
   mkdir -p "$TESTDIR/work"

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -71,4 +71,74 @@ test_removed_directory_is_not_readded_until_chpwd() {
   _wait_for_add "$TESTDIR/work"
   assert_eq "1" "$(zshz_rank_of "$TESTDIR/work")" "_zshz_chpwd should allow later re-addition"
 }
+
+test_precmd_does_not_emit_done_line_in_interactive_shell() {
+  # Verify the user-visible promise of `&!' in `_zshz_precmd': in an
+  # interactive shell, the backgrounded `zshz --add' must not produce
+  # a "[N]  + done" notification at the next prompt.
+  #
+  # The function-call boundary of `_zshz_precmd' alone is NOT enough to
+  # suppress that line -- with MONITOR on (default in interactive zsh),
+  # plain `cmd &' inside a function still surfaces a Done notification
+  # at the next prompt. `&!' (background + disown) is what suppresses it,
+  # and that's the contract this test pins down.
+  #
+  # The probe uses `zsh/zpty' to drive a real pty-backed interactive zsh.
+  # Reads are timing-based -- pattern-matched reads (`zpty -r p v PAT')
+  # are unreliable on zsh 4.3.11. Linux-only because of /proc/$$/exe;
+  # the existing concurrency suite is similarly Linux-coupled via
+  # `xargs -P'.
+  zmodload zsh/zpty 2>/dev/null
+  if ! (( ${+modules[zsh/zpty]} )); then
+    print "skip: zsh/zpty unavailable"
+    return 0
+  fi
+
+  local zsh_bin
+  zsh_bin=$(readlink /proc/$$/exe 2>/dev/null)
+  [[ -x $zsh_bin ]] || zsh_bin=${commands[zsh]}
+  if [[ ! -x $zsh_bin ]]; then
+    print "skip: no zsh binary located"
+    return 0
+  fi
+
+  mkdir -p "$TESTDIR/work"
+
+  zpty -b z_probe "$zsh_bin -i --no-rcs -d -f" || {
+    fail "zpty -b failed"
+    return 1
+  }
+  sleep 0.3
+  zpty -w z_probe "PS1='ZTEST>'"$'\n'
+  zpty -w z_probe "setopt MONITOR"$'\n'
+  zpty -w z_probe "source '$PLUGIN_DIR/zsh-z.plugin.zsh'"$'\n'
+  zpty -w z_probe "cd '$TESTDIR/work'"$'\n'
+  zpty -w z_probe "_zshz_precmd"$'\n'
+  # Wait for the disowned `zshz --add' to finish writing the datafile.
+  sleep 0.5
+  # Send a no-op so any pending Done notification surfaces at the next
+  # prompt rendering.
+  zpty -w z_probe ":"$'\n'
+  sleep 0.2
+  zpty -w z_probe "exit"$'\n'
+  sleep 0.2
+
+  local out= chunk
+  while zpty -r z_probe chunk; do out+=$chunk; done 2>/dev/null
+  zpty -d z_probe 2>/dev/null
+
+  if [[ $out == *"+ done"* ]]; then
+    fail "&! promise broken: interactive precmd surfaced a '+ done' line"
+  fi
+
+  # Sanity: SOMETHING landed in the datafile. The interactive zpty
+  # session triggers precmd at every prompt (initial, after cd, after
+  # the `:'), so the exact rank is whatever-precmd-fired-times rather
+  # than 1. We only check that the write path worked at all.
+  local rank
+  rank=$(zshz_rank_of "$TESTDIR/work")
+  if [[ -z $rank ]] || (( rank < 1 )); then
+    fail "backgrounded write never landed (rank=$rank)"
+  fi
+}
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -1,0 +1,43 @@
+# Hook behavior for precmd/chpwd integration.
+
+test_precmd_adds_pwd_in_foreground() {
+  mkdir -p "$TESTDIR/work"
+  OSTYPE=cygwin
+  cd "$TESTDIR/work"
+
+  _zshz_precmd
+
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/work")" "_zshz_precmd should add PWD"
+}
+
+test_precmd_skips_home_and_excluded_dirs() {
+  local HOME="$TESTDIR/home"
+  mkdir -p "$HOME" "$TESTDIR/excluded/child"
+  ZSHZ_EXCLUDE_DIRS=( "$TESTDIR/excluded" )
+  OSTYPE=cygwin
+
+  cd "$HOME"
+  _zshz_precmd
+  assert_eq "" "$(zshz_rank_of "$HOME")" "_zshz_precmd should skip HOME"
+
+  cd "$TESTDIR/excluded/child"
+  _zshz_precmd
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/excluded/child")" "_zshz_precmd should skip excluded subtrees"
+}
+
+test_removed_directory_is_not_readded_until_chpwd() {
+  mkdir -p "$TESTDIR/work"
+  OSTYPE=cygwin
+  cd "$TESTDIR/work"
+
+  _zshz_precmd
+  zshz -x "$TESTDIR/work"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/work")" "directory should be removed by -x"
+
+  _zshz_precmd
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/work")" "_zshz_precmd should not immediately re-add a removed directory"
+
+  _zshz_chpwd
+  _zshz_precmd
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/work")" "_zshz_chpwd should allow later re-addition"
+}

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -1,15 +1,37 @@
 # Hook behavior for precmd/chpwd integration.
 #
-# These tests force OSTYPE=cygwin so `_zshz_precmd` takes its foreground write
-# path; otherwise it backgrounds `zshz --add`, which would make the assertions
-# racy.
+# `_zshz_precmd' backgrounds `zshz --add' via `&!' (fork + disown) so the
+# prompt doesn't wait on the read+tempfile+rename+chown round-trip. The
+# helper below waits for the disowned write to land before asserting; `wait'
+# can't see a `&!'-disowned job, so we poll the datafile.
 
-test_precmd_adds_pwd_in_foreground() {
+# Wait up to 2s for $1 to appear in the datafile. Returns 0 once the entry is
+# present, 1 on timeout.
+_wait_for_add() {
+  local target=$1 i
+  for ((i=0; i<40; i++)); do
+    [[ -n $(zshz_rank_of "$target") ]] && return 0
+    sleep 0.05
+  done
+  return 1
+}
+
+# Wait up to 2s for $1 to be absent from the datafile.
+_wait_for_remove() {
+  local target=$1 i
+  for ((i=0; i<40; i++)); do
+    [[ -z $(zshz_rank_of "$target") ]] && return 0
+    sleep 0.05
+  done
+  return 1
+}
+
+test_precmd_adds_pwd() {
   mkdir -p "$TESTDIR/work"
-  OSTYPE=cygwin
   cd "$TESTDIR/work"
 
   _zshz_precmd
+  _wait_for_add "$TESTDIR/work"
 
   assert_eq "1" "$(zshz_rank_of "$TESTDIR/work")" "_zshz_precmd should add PWD"
 }
@@ -18,10 +40,10 @@ test_precmd_skips_home_and_excluded_dirs() {
   local HOME="$TESTDIR/home"
   mkdir -p "$HOME" "$TESTDIR/excluded/child"
   ZSHZ_EXCLUDE_DIRS=( "$TESTDIR/excluded" )
-  OSTYPE=cygwin
 
   cd "$HOME"
   _zshz_precmd
+  # No backgrounded write to wait on -- precmd returns before reaching `&!'.
   assert_eq "" "$(zshz_rank_of "$HOME")" "_zshz_precmd should skip HOME"
 
   cd "$TESTDIR/excluded/child"
@@ -31,18 +53,22 @@ test_precmd_skips_home_and_excluded_dirs() {
 
 test_removed_directory_is_not_readded_until_chpwd() {
   mkdir -p "$TESTDIR/work"
-  OSTYPE=cygwin
   cd "$TESTDIR/work"
 
   _zshz_precmd
+  _wait_for_add "$TESTDIR/work"
   zshz -x "$TESTDIR/work"
   assert_eq "" "$(zshz_rank_of "$TESTDIR/work")" "directory should be removed by -x"
 
   _zshz_precmd
+  # The DIRECTORY_REMOVED guard makes precmd return early, so no add to wait
+  # for; sleep briefly to confirm nothing sneaks in late.
+  sleep 0.1
   assert_eq "" "$(zshz_rank_of "$TESTDIR/work")" "_zshz_precmd should not immediately re-add a removed directory"
 
   _zshz_chpwd
   _zshz_precmd
+  _wait_for_add "$TESTDIR/work"
   assert_eq "1" "$(zshz_rank_of "$TESTDIR/work")" "_zshz_chpwd should allow later re-addition"
 }
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -45,3 +45,4 @@ test_removed_directory_is_not_readded_until_chpwd() {
   _zshz_precmd
   assert_eq "1" "$(zshz_rank_of "$TESTDIR/work")" "_zshz_chpwd should allow later re-addition"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -85,9 +85,14 @@ test_precmd_does_not_emit_done_line_in_interactive_shell() {
   #
   # The probe uses `zsh/zpty' to drive a real pty-backed interactive zsh.
   # Reads are timing-based -- pattern-matched reads (`zpty -r p v PAT')
-  # are unreliable on zsh 4.3.11. Linux-only because of /proc/$$/exe;
-  # the existing concurrency suite is similarly Linux-coupled via
-  # `xargs -P'.
+  # are unreliable on zsh 4.3.11, and the fixed sleeps below assume
+  # Linux pty timing. On Solaris the pty isn't ready quickly enough,
+  # eating the first character of `PS1=' and derailing the subsequent
+  # `cd' (the inner shell drops into a `>>>' continuation prompt and
+  # later precmd calls record $TESTDIR instead of $TESTDIR/work). The
+  # contract being tested -- that `&!' suppresses the "Done" line --
+  # is inherent to zsh's job control, so Linux coverage is enough.
+  [[ $OSTYPE == linux* ]] || { print "skip: non-Linux pty timing"; return 0 }
   zmodload zsh/zpty 2>/dev/null
   if ! (( ${+modules[zsh/zpty]} )); then
     print "skip: zsh/zpty unavailable"

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -225,10 +225,14 @@ test_repeated_precmd_under_prompt_spam() {
 
   # And several disowned writes must have landed. We don't expect rank
   # == n: the children all race for the lockfile, and ZSHZ_LOCK_TIMEOUT
-  # may legitimately drop a few. We expect a clear majority though.
-  local rank
+  # may legitimately drop a few. We expect a clear majority though --
+  # except on zsh 4.3.11, whose fork machinery is slow enough that most
+  # of the 30 children miss the 1s lock window. Relax the floor there
+  # to "the precmd path produced more than one write."
+  local rank min_rank=5
+  is-at-least 5 || min_rank=2
   rank=$(zshz_rank_of "$TESTDIR/work")
-  if [[ -z $rank ]] || (( rank < 5 )); then
+  if [[ -z $rank ]] || (( rank < min_rank )); then
     fail "expected several disowned writes to land; got rank=${rank:-(empty)}"
   fi
 }

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -151,7 +151,13 @@ test_precmd_does_not_emit_done_line_in_interactive_shell() {
   if [[ -z $rank ]] || (( rank < 1 )); then
     local dump
     dump=$(zshz_dump)
-    fail "backgrounded write never landed (rank=$rank); looked up '$TESTDIR/work'; datafile: ${dump:-<empty>}"
+    # On a failure here, the most useful thing to see is what the inner
+    # zsh actually printed back -- a cd error, a parse error on some
+    # input line, or just a missing prompt all look the same from the
+    # outside otherwise. `$out' was already drained above for the
+    # `+ done' check; reuse it.
+    local pty_out=${out//$'\r'/}
+    fail "backgrounded write never landed (rank=$rank); looked up '$TESTDIR/work'; datafile: ${dump:-<empty>}; pty output: <<<${pty_out}>>>"
   fi
 }
 

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -135,10 +135,23 @@ test_precmd_does_not_emit_done_line_in_interactive_shell() {
   # session triggers precmd at every prompt (initial, after cd, after
   # the `:'), so the exact rank is whatever-precmd-fired-times rather
   # than 1. We only check that the write path worked at all.
-  local rank
-  rank=$(zshz_rank_of "$TESTDIR/work")
+  #
+  # The disowned `zshz --add' is reparented to init when zpty -d closes
+  # the inner zsh, and may not have finished writing by the time we
+  # reach this point on a slow host. Poll for up to 5s. On failure,
+  # dump the datafile so a path mismatch (e.g. /tmp resolving to a
+  # different canonical path inside the zpty session) is distinguishable
+  # from a missed-write timeout.
+  local rank deadline=$(( EPOCHSECONDS + 5 ))
+  while (( EPOCHSECONDS < deadline )); do
+    rank=$(zshz_rank_of "$TESTDIR/work")
+    [[ -n $rank ]] && (( rank >= 1 )) && break
+    sleep 0.1
+  done
   if [[ -z $rank ]] || (( rank < 1 )); then
-    fail "backgrounded write never landed (rank=$rank)"
+    local dump
+    dump=$(zshz_dump)
+    fail "backgrounded write never landed (rank=$rank); looked up '$TESTDIR/work'; datafile: ${dump:-<empty>}"
   fi
 }
 

--- a/tests/test_hooks.zsh
+++ b/tests/test_hooks.zsh
@@ -104,10 +104,16 @@ test_precmd_does_not_emit_done_line_in_interactive_shell() {
 
   mkdir -p "$TESTDIR/work"
 
-  zpty -b z_probe "$zsh_bin -i --no-rcs -d -f" || {
-    fail "zpty -b failed"
-    return 1
-  }
+  # `zpty -b' can fail even after `zmodload zsh/zpty' succeeds: on
+  # Cygwin the module loads but no pseudo-terminal is available
+  # ("can't open pseudo terminal: bad file descriptor"). Treat that as
+  # a platform skip rather than a test failure -- if the inner zsh
+  # can't get a pty, the &!/Done-line behavior simply can't be
+  # exercised here.
+  if ! zpty -b z_probe "$zsh_bin -i --no-rcs -d -f" 2>/dev/null; then
+    print "skip: zpty cannot open a pty on this platform"
+    return 0
+  fi
   sleep 0.3
   zpty -w z_probe "PS1='ZTEST>'"$'\n'
   zpty -w z_probe "setopt MONITOR"$'\n'

--- a/tests/test_keep_dirs.zsh
+++ b/tests/test_keep_dirs.zsh
@@ -1,0 +1,107 @@
+# `ZSHZ_KEEP_DIRS': edge cases beyond the simple subtree-protection
+# already covered by `test_cleanup.zsh'.
+#
+# `_zshz_update_datafile' (line 401-) and `_zshz_find_matches'
+# (line 671-) both run the same prune-missing-directories loop:
+# entries whose backing dir doesn't exist are dropped UNLESS the
+# entry path matches `${keep}/*', equals `$keep', or `$keep' itself
+# is `/'. Both call sites must honour KEEP_DIRS the same way -- the
+# rewrite-time pruning is what `test_cleanup.zsh' covers; the
+# read-time pruning is what one of these tests covers.
+
+test_keep_dirs_protects_many_entries_under_one_root() {
+  # Stronger version of `test_keep_dirs_protects_subtree': several
+  # entries under one KEEP_DIRS root, all preserved at their original
+  # ranks, after the dir is deleted and a rewrite is forced.
+  mkdir -p "$TESTDIR/holdme/a" "$TESTDIR/holdme/b" "$TESTDIR/holdme/c/inner" "$TESTDIR/trigger"
+  zshz_seed "$TESTDIR/holdme/a"        3 60
+  zshz_seed "$TESTDIR/holdme/b"        7 60
+  zshz_seed "$TESTDIR/holdme/c/inner" 11 60
+  rm -rf "$TESTDIR/holdme"
+
+  ZSHZ_KEEP_DIRS=( "$TESTDIR/holdme" ) zshz --add "$TESTDIR/trigger"
+
+  assert_eq "3"  "$(zshz_rank_of "$TESTDIR/holdme/a")"        "first kept entry"
+  assert_eq "7"  "$(zshz_rank_of "$TESTDIR/holdme/b")"        "second kept entry"
+  assert_eq "11" "$(zshz_rank_of "$TESTDIR/holdme/c/inner")"  "third kept entry"
+}
+
+test_keep_dirs_root_slash_protects_everything() {
+  # The `$dir == '/'' branch: `KEEP_DIRS=( / )' is a documented
+  # escape hatch that suppresses the missing-dir prune entirely.
+  # `test_scale.zsh' relies on this so it doesn't have to mkdir
+  # 5000 stub directories; the contract had no dedicated test
+  # before this one.
+  mkdir -p "$TESTDIR/elsewhere1" "$TESTDIR/elsewhere2" "$TESTDIR/trigger"
+  zshz_seed "$TESTDIR/elsewhere1" 5 60
+  zshz_seed "$TESTDIR/elsewhere2" 9 60
+  rm -rf "$TESTDIR/elsewhere1" "$TESTDIR/elsewhere2"
+
+  ZSHZ_KEEP_DIRS=( / ) zshz --add "$TESTDIR/trigger"
+
+  assert_eq "5" "$(zshz_rank_of "$TESTDIR/elsewhere1")" \
+    "KEEP_DIRS=(/) should keep any missing entry, regardless of path"
+  assert_eq "9" "$(zshz_rank_of "$TESTDIR/elsewhere2")" \
+    "KEEP_DIRS=(/) should keep every missing entry"
+}
+
+test_keep_dirs_does_not_protect_prefix_sibling() {
+  # The keep test is `${line%%\|*} == ${dir}/* || ${line%%\|*} == $dir',
+  # so excluding `/foo' must not keep `/foobar' (same boundary as the
+  # ZSHZ_EXCLUDE_DIRS pattern in `test_manual_add.zsh').
+  mkdir -p "$TESTDIR/holdme" "$TESTDIR/holdmeSibling" "$TESTDIR/trigger"
+  zshz_seed "$TESTDIR/holdme"        3 60
+  zshz_seed "$TESTDIR/holdmeSibling" 7 60
+  rm -rf "$TESTDIR/holdme" "$TESTDIR/holdmeSibling"
+
+  ZSHZ_KEEP_DIRS=( "$TESTDIR/holdme" ) zshz --add "$TESTDIR/trigger"
+
+  assert_eq "3" "$(zshz_rank_of "$TESTDIR/holdme")" \
+    "the exact KEEP_DIRS path should survive"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/holdmeSibling")" \
+    "a prefix-sibling of a KEEP_DIRS entry must not be protected"
+}
+
+test_keep_dirs_with_multiple_entries_each_protects_independently() {
+  # Three different KEEP_DIRS entries; each protects its own path.
+  mkdir -p "$TESTDIR/k1/inner" "$TESTDIR/k2" "$TESTDIR/k3" \
+           "$TESTDIR/dropme" "$TESTDIR/trigger"
+  zshz_seed "$TESTDIR/k1/inner" 1 60
+  zshz_seed "$TESTDIR/k2"       2 60
+  zshz_seed "$TESTDIR/k3"       3 60
+  zshz_seed "$TESTDIR/dropme"   9 60
+  rm -rf "$TESTDIR/k1" "$TESTDIR/k2" "$TESTDIR/k3" "$TESTDIR/dropme"
+
+  ZSHZ_KEEP_DIRS=( "$TESTDIR/k1" "$TESTDIR/k2" "$TESTDIR/k3" ) \
+    zshz --add "$TESTDIR/trigger"
+
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/k1/inner")" "k1 subtree kept"
+  assert_eq "2" "$(zshz_rank_of "$TESTDIR/k2")"       "k2 exact kept"
+  assert_eq "3" "$(zshz_rank_of "$TESTDIR/k3")"       "k3 exact kept"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/dropme")" \
+    "an entry not under any KEEP_DIRS root should still be pruned"
+}
+
+test_keep_dirs_affects_read_time_listing() {
+  # `_zshz_find_matches' applies the same prune. A missing-dir entry
+  # must not surface in `zshz -l' unless KEEP_DIRS protects it.
+  # This pins the read-side branch (the rewrite-side branch is
+  # exercised by every other test in this file via `--add').
+  mkdir -p "$TESTDIR/visible" "$TESTDIR/hidden"
+  zshz_seed "$TESTDIR/visible" 1 60
+  zshz_seed "$TESTDIR/hidden"  1 60
+  rm -rf "$TESTDIR/hidden"
+
+  # Without KEEP_DIRS, the hidden entry is filtered from `-l'.
+  local out
+  out=$(zshz -l)
+  assert_contains "$TESTDIR/visible" "$out" "visible entry must be listed"
+  assert_not_contains "$TESTDIR/hidden" "$out" \
+    "missing-dir entry must be filtered from -l"
+
+  # With KEEP_DIRS protecting it, the hidden entry surfaces.
+  out=$(ZSHZ_KEEP_DIRS=( "$TESTDIR/hidden" ) zshz -l)
+  assert_contains "$TESTDIR/hidden" "$out" \
+    "KEEP_DIRS-protected entry must surface in -l despite missing dir"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_legacy_env.zsh
+++ b/tests/test_legacy_env.zsh
@@ -31,7 +31,8 @@ test__Z_MAX_SCORE_controls_aging() {
     zshz --add "$TESTDIR/x"
   done
 
-  local rank=$(zshz_rank_of "$TESTDIR/x")
+  local rank
+  rank=$(zshz_rank_of "$TESTDIR/x")
   [[ -n $rank ]] || fail "rank should be present"
   (( rank < 7 )) || fail "_Z_MAX_SCORE should trigger aging before rank reaches 7, was $rank"
   (( rank > 6 )) || fail "aged rank should still stay above 6, was $rank"

--- a/tests/test_legacy_env.zsh
+++ b/tests/test_legacy_env.zsh
@@ -1,0 +1,49 @@
+# Compatibility with legacy _Z_* environment variables.
+
+test__Z_DATA_selects_legacy_datafile() {
+  local legacy_data="$TESTDIR/legacy.z"
+  mkdir -p "$TESTDIR/work"
+
+  unset ZSHZ_DATA
+  _Z_DATA="$legacy_data" zshz --add "$TESTDIR/work"
+
+  assert_file_exists "$legacy_data"
+  assert_contains "$TESTDIR/work|1|" "$(cat "$legacy_data")" "_Z_DATA should choose the legacy datafile path"
+}
+
+test__Z_CMD_defines_legacy_alias_name() {
+  local out
+  out=$(zsh --no-rcs -c "
+    _Z_CMD=zoo
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    print -- \${aliases[zoo]:-NONE}
+  ")
+
+  assert_eq "zshz 2>&1" "$out" "_Z_CMD should define the alias under the legacy command name"
+}
+
+test__Z_MAX_SCORE_controls_aging() {
+  mkdir -p "$TESTDIR/x"
+  local i
+
+  _Z_MAX_SCORE=5
+  for i in {1..7}; do
+    zshz --add "$TESTDIR/x"
+  done
+
+  local rank=$(zshz_rank_of "$TESTDIR/x")
+  [[ -n $rank ]] || fail "rank should be present"
+  (( rank < 7 )) || fail "_Z_MAX_SCORE should trigger aging before rank reaches 7, was $rank"
+  (( rank > 6 )) || fail "aged rank should still stay above 6, was $rank"
+}
+
+test__Z_NO_RESOLVE_SYMLINKS_stores_link_path() {
+  local target="$TESTDIR/target" link="$TESTDIR/link"
+  mkdir -p "$target"
+  ln -s "$target" "$link"
+
+  _Z_NO_RESOLVE_SYMLINKS=1 zshz --add "$link"
+
+  assert_eq "1" "$(zshz_rank_of "$link")" "_Z_NO_RESOLVE_SYMLINKS should store the symlink path"
+  assert_eq "" "$(zshz_rank_of "$target")" "_Z_NO_RESOLVE_SYMLINKS should not store the resolved target"
+}

--- a/tests/test_legacy_env.zsh
+++ b/tests/test_legacy_env.zsh
@@ -48,3 +48,4 @@ test__Z_NO_RESOLVE_SYMLINKS_stores_link_path() {
   assert_eq "1" "$(zshz_rank_of "$link")" "_Z_NO_RESOLVE_SYMLINKS should store the symlink path"
   assert_eq "" "$(zshz_rank_of "$target")" "_Z_NO_RESOLVE_SYMLINKS should not store the resolved target"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_listing.zsh
+++ b/tests/test_listing.zsh
@@ -1,0 +1,45 @@
+# Listing output and ordering semantics.
+
+test_no_args_matches_list_output() {
+  mkdir -p "$TESTDIR/a" "$TESTDIR/b"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/a|5|$((now - 60))" \
+    "$TESTDIR/b|10|$((now - 120))" \
+    > "$ZSHZ_DATA"
+
+  assert_eq "$(zshz -l)" "$(zshz)" "calling zshz with no args should behave like -l"
+}
+
+test_list_rank_and_time_modes_order_entries() {
+  mkdir -p "$TESTDIR/a" "$TESTDIR/b"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/a|5|$((now - 60))" \
+    "$TESTDIR/b|10|$((now - 120))" \
+    > "$ZSHZ_DATA"
+
+  local rank_out=$(zshz -lr)
+  local -a rank_lines=( ${(f)rank_out} )
+  assert_contains "$TESTDIR/a" "$rank_lines[1]" "-lr should list the lower-rank entry first"
+  assert_contains "$TESTDIR/b" "$rank_lines[2]" "-lr should list the higher-rank entry second"
+
+  local time_out=$(zshz -lt)
+  local -a time_lines=( ${(f)time_out} )
+  assert_contains "$TESTDIR/b" "$time_lines[1]" "-lt should list the older entry first"
+  assert_contains "$TESTDIR/a" "$time_lines[2]" "-lt should list the newer entry second"
+}
+
+test_list_prints_common_root_line() {
+  mkdir -p "$TESTDIR/foo" "$TESTDIR/foo/bar"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/foo|1|$now" \
+    "$TESTDIR/foo/bar|2|$now" \
+    > "$ZSHZ_DATA"
+
+  local out=$(zshz -l foo)
+  local -a lines=( ${(f)out} )
+  assert_contains "common:" "$lines[1]" "-l should print a common-root summary when multiple matches share one"
+  assert_contains "$TESTDIR/foo" "$lines[1]" "common-root summary should show the shared root"
+}

--- a/tests/test_listing.zsh
+++ b/tests/test_listing.zsh
@@ -2,22 +2,16 @@
 
 test_no_args_matches_list_output() {
   mkdir -p "$TESTDIR/a" "$TESTDIR/b"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/a|5|$((now - 60))" \
-    "$TESTDIR/b|10|$((now - 120))" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/a" 5 60
+  zshz_seed "$TESTDIR/b" 10 120
 
   assert_eq "$(zshz -l)" "$(zshz)" "calling zshz with no args should behave like -l"
 }
 
 test_list_rank_and_time_modes_order_entries() {
   mkdir -p "$TESTDIR/a" "$TESTDIR/b"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/a|5|$((now - 60))" \
-    "$TESTDIR/b|10|$((now - 120))" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/a" 5 60
+  zshz_seed "$TESTDIR/b" 10 120
 
   local rank_out=$(zshz -lr)
   local -a rank_lines=( ${(f)rank_out} )
@@ -32,11 +26,8 @@ test_list_rank_and_time_modes_order_entries() {
 
 test_list_prints_common_root_line() {
   mkdir -p "$TESTDIR/foo" "$TESTDIR/foo/bar"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/foo|1|$now" \
-    "$TESTDIR/foo/bar|2|$now" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/foo" 1
+  zshz_seed "$TESTDIR/foo/bar" 2
 
   local out=$(zshz -l foo)
   local -a lines=( ${(f)out} )

--- a/tests/test_listing.zsh
+++ b/tests/test_listing.zsh
@@ -13,13 +13,17 @@ test_list_rank_and_time_modes_order_entries() {
   zshz_seed "$TESTDIR/a" 5 60
   zshz_seed "$TESTDIR/b" 10 120
 
-  local rank_out=$(zshz -lr)
-  local -a rank_lines=( ${(f)rank_out} )
+  local rank_out
+  local -a rank_lines
+  rank_out=$(zshz -lr)
+  rank_lines=( ${(f)rank_out} )
   assert_contains "$TESTDIR/a" "$rank_lines[1]" "-lr should list the lower-rank entry first"
   assert_contains "$TESTDIR/b" "$rank_lines[2]" "-lr should list the higher-rank entry second"
 
-  local time_out=$(zshz -lt)
-  local -a time_lines=( ${(f)time_out} )
+  local time_out
+  local -a time_lines
+  time_out=$(zshz -lt)
+  time_lines=( ${(f)time_out} )
   assert_contains "$TESTDIR/b" "$time_lines[1]" "-lt should list the older entry first"
   assert_contains "$TESTDIR/a" "$time_lines[2]" "-lt should list the newer entry second"
 }
@@ -29,8 +33,10 @@ test_list_prints_common_root_line() {
   zshz_seed "$TESTDIR/foo" 1
   zshz_seed "$TESTDIR/foo/bar" 2
 
-  local out=$(zshz -l foo)
-  local -a lines=( ${(f)out} )
+  local out
+  local -a lines
+  out=$(zshz -l foo)
+  lines=( ${(f)out} )
   assert_contains "common:" "$lines[1]" "-l should print a common-root summary when multiple matches share one"
   assert_contains "$TESTDIR/foo" "$lines[1]" "common-root summary should show the shared root"
 }

--- a/tests/test_listing.zsh
+++ b/tests/test_listing.zsh
@@ -40,3 +40,4 @@ test_list_prints_common_root_line() {
   assert_contains "common:" "$lines[1]" "-l should print a common-root summary when multiple matches share one"
   assert_contains "$TESTDIR/foo" "$lines[1]" "common-root summary should show the shared root"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_lock_timeout.zsh
+++ b/tests/test_lock_timeout.zsh
@@ -1,0 +1,100 @@
+# `ZSHZ_LOCK_TIMEOUT' must actually fire and degrade gracefully.
+#
+# When some other process holds the lockfile, `zshz --add' must give
+# up after `ZSHZ_LOCK_TIMEOUT' seconds (default 1) rather than blocking
+# the prompt indefinitely. The dropped update is the cost; the prompt
+# staying responsive is the benefit. This file pins three properties:
+#   1. The call returns within ~1.5s of a 1s timeout.
+#   2. It exits non-zero (the user/caller can detect the failure).
+#   3. The datafile is unchanged -- no half-write, no rewrite that
+#      drops pre-existing entries.
+
+test_lock_timeout_fires_when_lock_held_externally() {
+  # We need `zsystem flock' for both the holder and the contender.
+  # The plugin loads `zsh/system' itself; if it isn't available, the
+  # plugin runs the no-flock path and there's no timeout to test.
+  if ! (( ZSHZ[USE_FLOCK] )); then
+    print "skip: zsystem flock unavailable"
+    return 0
+  fi
+
+  mkdir -p "$TESTDIR/target"
+  zshz_seed "$TESTDIR/seed" 7 60
+  touch "${ZSHZ_DATA}.lock"
+
+  # Spawn an external holder. `zsystem flock' (no -f) acquires the
+  # lock on a hidden fd that the shell holds for its lifetime; the
+  # `sleep' keeps the holder alive long enough for our contender to
+  # hit the timeout. The lock must live in a separate process (POSIX
+  # advisory locks are per-process; flock from the runner shell
+  # wouldn't contend with itself).
+  #
+  # Background with `&!' (fork+disown) rather than `&' because zsh
+  # 4.3.11's `&'/`wait' machinery segfaults even under light fork
+  # load -- cf. test_concurrency.zsh. With `&!' there's no entry to
+  # `wait' on; the holder self-terminates when its sleep ends.
+  zsh --no-rcs -c "
+    zmodload zsh/system
+    zsystem flock '${ZSHZ_DATA}.lock'
+    sleep 3
+  " &!
+  local holder=$!
+
+  # Give the holder time to acquire the lock before we start the
+  # contender. Without this, `zshz --add' could win the race and the
+  # test would test nothing.
+  sleep 0.2
+
+  typeset -F SECONDS=0
+  ZSHZ_LOCK_TIMEOUT=1 zshz --add "$TESTDIR/target"
+  local rc=$?
+  local elapsed=$SECONDS
+
+  # Best-effort cleanup so the holder doesn't outlive the test for
+  # too long. The holder is already disowned, so no `wait'.
+  kill $holder 2>/dev/null
+
+  # 1. Non-zero return.
+  assert_ne "0" "$rc" "--add should fail when the lock can't be acquired"
+
+  # 2. Bounded duration. Generous upper bound (3s) to absorb scheduler
+  #    jitter in CI; the timeout itself is 1s.
+  if (( elapsed > 3 )); then
+    fail "--add should give up within ~1s; took ${elapsed}s"
+  fi
+  # And it shouldn't return *before* the timeout either, which would
+  # mean the lock wasn't held when we ran -- our holder lost the race.
+  if (( elapsed < 0.5 )); then
+    fail "--add returned before the timeout (${elapsed}s); the holder may have lost the race"
+  fi
+
+  # 3. Datafile unchanged: target not added, seed entry intact.
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/target")" \
+    "target should not have been added when lock acquisition failed"
+  assert_eq "7" "$(zshz_rank_of "$TESTDIR/seed")" \
+    "pre-existing entry should be unchanged after a failed --add"
+}
+
+test_lock_timeout_succeeds_when_lock_free() {
+  # Control: with no contender, --add should succeed in well under
+  # the timeout. Guards against the test above accidentally passing
+  # for the wrong reason (e.g. if the timeout assertions were too
+  # loose to distinguish failure from success).
+  if ! (( ZSHZ[USE_FLOCK] )); then
+    print "skip: zsystem flock unavailable"
+    return 0
+  fi
+
+  mkdir -p "$TESTDIR/target"
+  typeset -F SECONDS=0
+  ZSHZ_LOCK_TIMEOUT=1 zshz --add "$TESTDIR/target"
+  local rc=$? elapsed=$SECONDS
+
+  assert_eq "0" "$rc" "--add should succeed when no one holds the lock"
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/target")" \
+    "target should be in the datafile after a successful --add"
+  if (( elapsed > 0.5 )); then
+    fail "uncontended --add should be fast; took ${elapsed}s"
+  fi
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_manual_add.zsh
+++ b/tests/test_manual_add.zsh
@@ -1,0 +1,95 @@
+# Pin the manual-`--add' defenses in `_zshz_add_or_remove_path' (the
+# block at zsh-z.plugin.zsh:210-224 that rejects $HOME and any path
+# under ZSHZ_EXCLUDE_DIRS). The same checks live in `_zshz_precmd' for
+# the prompt path; this set covers the user-typed `zshz --add ...'
+# entry point, which bypasses precmd entirely.
+#
+# Pins behaviour both ways: a future "remove the redundant block"
+# rewrite would change pass-3 (these tests would start failing) and a
+# future "tighten the comparison" rewrite (e.g., quote-the-RHS for
+# $HOME) should not change observable behaviour for any of these cases.
+
+test_manual_add_of_HOME_is_rejected() {
+  local HOME="$TESTDIR/home"
+  mkdir -p "$HOME"
+
+  zshz --add "$HOME"
+  assert_eq "" "$(zshz_rank_of "$HOME")" \
+    "manual --add of \$HOME should not create an entry"
+}
+
+test_manual_add_of_exact_excluded_dir_is_rejected() {
+  mkdir -p "$TESTDIR/excluded"
+  ZSHZ_EXCLUDE_DIRS=( "$TESTDIR/excluded" )
+
+  zshz --add "$TESTDIR/excluded"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/excluded")" \
+    "manual --add of an excluded directory itself should not create an entry"
+}
+
+test_manual_add_of_subdir_of_excluded_dir_is_rejected() {
+  mkdir -p "$TESTDIR/excluded/inner/deeper"
+  ZSHZ_EXCLUDE_DIRS=( "$TESTDIR/excluded" )
+
+  zshz --add "$TESTDIR/excluded/inner"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/excluded/inner")" \
+    "subdir of an excluded directory should not create an entry"
+
+  zshz --add "$TESTDIR/excluded/inner/deeper"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/excluded/inner/deeper")" \
+    "deeper subdir of an excluded directory should not create an entry"
+}
+
+test_manual_add_of_prefix_sibling_of_excluded_is_allowed() {
+  # The exclude pattern is `${exclude}|${exclude}/*' -- it matches the
+  # excluded directory itself OR any subdirectory, but NOT a sibling
+  # whose name happens to share the same prefix. e.g. excluding
+  # `/foo' must not exclude `/foobar'.
+  mkdir -p "$TESTDIR/excluded" "$TESTDIR/excludedSibling"
+  ZSHZ_EXCLUDE_DIRS=( "$TESTDIR/excluded" )
+
+  zshz --add "$TESTDIR/excludedSibling"
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/excludedSibling")" \
+    "prefix-sibling of an excluded dir should still be added"
+}
+
+test_manual_add_of_unrelated_path_is_added() {
+  # Control: with $HOME and ZSHZ_EXCLUDE_DIRS set, an unrelated path
+  # must round-trip normally so we know the rejection logic isn't
+  # over-broad.
+  local HOME="$TESTDIR/home"
+  mkdir -p "$HOME" "$TESTDIR/excluded" "$TESTDIR/work"
+  ZSHZ_EXCLUDE_DIRS=( "$TESTDIR/excluded" )
+
+  zshz --add "$TESTDIR/work"
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/work")" \
+    "an unrelated path should be added even when HOME and excludes are set"
+}
+
+test_manual_add_legacy_Z_EXCLUDE_DIRS_also_rejects() {
+  # The exclude check reads `${ZSHZ_EXCLUDE_DIRS:-${_Z_EXCLUDE_DIRS}}',
+  # so the legacy `_Z_EXCLUDE_DIRS' should still be honoured when
+  # `ZSHZ_EXCLUDE_DIRS' is unset.
+  mkdir -p "$TESTDIR/excluded/inner"
+  unset ZSHZ_EXCLUDE_DIRS
+  _Z_EXCLUDE_DIRS=( "$TESTDIR/excluded" )
+
+  zshz --add "$TESTDIR/excluded/inner"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/excluded/inner")" \
+    "legacy _Z_EXCLUDE_DIRS should still cause manual --add to skip"
+}
+
+test_manual_add_of_multiple_excludes_each_rejects() {
+  # Multiple exclude entries: each independently triggers rejection.
+  mkdir -p "$TESTDIR/ex1" "$TESTDIR/ex2/inner" "$TESTDIR/ex3"
+  ZSHZ_EXCLUDE_DIRS=( "$TESTDIR/ex1" "$TESTDIR/ex2" "$TESTDIR/ex3" )
+
+  zshz --add "$TESTDIR/ex1"
+  zshz --add "$TESTDIR/ex2/inner"
+  zshz --add "$TESTDIR/ex3"
+
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/ex1")" "first exclude entry should reject"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/ex2/inner")" "second exclude entry should reject (subdir)"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/ex3")" "third exclude entry should reject"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_matching.zsh
+++ b/tests/test_matching.zsh
@@ -1,0 +1,67 @@
+# Frecency, rank-only (-r), and time-only (-t) matching.
+#
+# Each test seeds the datafile with synthetic rank/time values (paths must
+# exist on disk or stale-cleanup would remove them) and asserts which entry
+# wins. These tests lock in the scoring formula at zsh-z.plugin.zsh:661.
+
+test_frecency_higher_rank_wins_at_equal_time() {
+  mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/t/aa|1|$((now - 60))" \
+    "$TESTDIR/t/bb|100|$((now - 60))" \
+    > "$ZSHZ_DATA"
+  assert_eq "$TESTDIR/t/bb" "$(zshz -e t)" "higher rank wins when times are equal"
+}
+
+test_frecency_recent_wins_at_equal_rank() {
+  mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/t/aa|10|$((now - 60))" \
+    "$TESTDIR/t/bb|10|$((now - 86400))" \
+    > "$ZSHZ_DATA"
+  assert_eq "$TESTDIR/t/aa" "$(zshz -e t)" "more recent wins when ranks are equal"
+}
+
+test_frecency_high_rank_old_beats_low_rank_recent() {
+  # 1000 from a day ago vs 1 from 5 minutes ago: rank dominance still wins
+  mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/t/aa|1000|$((now - 86400))" \
+    "$TESTDIR/t/bb|1|$((now - 300))" \
+    > "$ZSHZ_DATA"
+  assert_eq "$TESTDIR/t/aa" "$(zshz -e t)" "very high rank still wins despite age"
+}
+
+test_frecency_recent_low_rank_beats_old_higher_rank() {
+  # rank 10 a minute ago vs rank 20 a day ago: recency wins
+  mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/t/aa|10|$((now - 60))" \
+    "$TESTDIR/t/bb|20|$((now - 86400))" \
+    > "$ZSHZ_DATA"
+  assert_eq "$TESTDIR/t/aa" "$(zshz -e t)" "moderate recency beats moderately higher old rank"
+}
+
+test_rank_match_picks_highest_rank_ignoring_time() {
+  mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/t/aa|5|$((now - 60))" \
+    "$TESTDIR/t/bb|10|$((now - 31536000))" \
+    > "$ZSHZ_DATA"
+  assert_eq "$TESTDIR/t/bb" "$(zshz -re t)" "-r should pick higher rank regardless of age"
+}
+
+test_time_match_picks_most_recent_ignoring_rank() {
+  mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/t/aa|1|$((now - 60))" \
+    "$TESTDIR/t/bb|100|$((now - 86400))" \
+    > "$ZSHZ_DATA"
+  assert_eq "$TESTDIR/t/aa" "$(zshz -te t)" "-t should pick more recent regardless of rank"
+}

--- a/tests/test_matching.zsh
+++ b/tests/test_matching.zsh
@@ -48,3 +48,4 @@ test_time_match_picks_most_recent_ignoring_rank() {
   zshz_seed "$TESTDIR/t/bb" 100 86400
   assert_eq "$TESTDIR/t/aa" "$(zshz -te t)" "-t should pick more recent regardless of rank"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_matching.zsh
+++ b/tests/test_matching.zsh
@@ -6,62 +6,44 @@
 
 test_frecency_higher_rank_wins_at_equal_time() {
   mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/t/aa|1|$((now - 60))" \
-    "$TESTDIR/t/bb|100|$((now - 60))" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/t/aa" 1 60
+  zshz_seed "$TESTDIR/t/bb" 100 60
   assert_eq "$TESTDIR/t/bb" "$(zshz -e t)" "higher rank wins when times are equal"
 }
 
 test_frecency_recent_wins_at_equal_rank() {
   mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/t/aa|10|$((now - 60))" \
-    "$TESTDIR/t/bb|10|$((now - 86400))" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/t/aa" 10 60
+  zshz_seed "$TESTDIR/t/bb" 10 86400
   assert_eq "$TESTDIR/t/aa" "$(zshz -e t)" "more recent wins when ranks are equal"
 }
 
 test_frecency_high_rank_old_beats_low_rank_recent() {
   # 1000 from a day ago vs 1 from 5 minutes ago: rank dominance still wins
   mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/t/aa|1000|$((now - 86400))" \
-    "$TESTDIR/t/bb|1|$((now - 300))" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/t/aa" 1000 86400
+  zshz_seed "$TESTDIR/t/bb" 1 300
   assert_eq "$TESTDIR/t/aa" "$(zshz -e t)" "very high rank still wins despite age"
 }
 
 test_frecency_recent_low_rank_beats_old_higher_rank() {
   # rank 10 a minute ago vs rank 20 a day ago: recency wins
   mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/t/aa|10|$((now - 60))" \
-    "$TESTDIR/t/bb|20|$((now - 86400))" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/t/aa" 10 60
+  zshz_seed "$TESTDIR/t/bb" 20 86400
   assert_eq "$TESTDIR/t/aa" "$(zshz -e t)" "moderate recency beats moderately higher old rank"
 }
 
 test_rank_match_picks_highest_rank_ignoring_time() {
   mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/t/aa|5|$((now - 60))" \
-    "$TESTDIR/t/bb|10|$((now - 31536000))" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/t/aa" 5 60
+  zshz_seed "$TESTDIR/t/bb" 10 31536000
   assert_eq "$TESTDIR/t/bb" "$(zshz -re t)" "-r should pick higher rank regardless of age"
 }
 
 test_time_match_picks_most_recent_ignoring_rank() {
   mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/t/aa|1|$((now - 60))" \
-    "$TESTDIR/t/bb|100|$((now - 86400))" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/t/aa" 1 60
+  zshz_seed "$TESTDIR/t/bb" 100 86400
   assert_eq "$TESTDIR/t/aa" "$(zshz -te t)" "-t should pick more recent regardless of rank"
 }

--- a/tests/test_matching.zsh
+++ b/tests/test_matching.zsh
@@ -2,7 +2,8 @@
 #
 # Each test seeds the datafile with synthetic rank/time values (paths must
 # exist on disk or stale-cleanup would remove them) and asserts which entry
-# wins. These tests lock in the scoring formula at zsh-z.plugin.zsh:661.
+# wins. These tests lock in the frecency calculation used by
+# `_zshz_find_matches`.
 
 test_frecency_higher_rank_wins_at_equal_time() {
   mkdir -p "$TESTDIR/t/aa" "$TESTDIR/t/bb"

--- a/tests/test_no_flock.zsh
+++ b/tests/test_no_flock.zsh
@@ -26,3 +26,4 @@ test_no_lockfile_created_without_flock() {
     fail "lockfile should not be created when USE_FLOCK=0"
   fi
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_no_flock.zsh
+++ b/tests/test_no_flock.zsh
@@ -1,7 +1,7 @@
-# ZSHZ[USE_FLOCK]=0 fallback path: when zsh/system isn't available, Zsh-z
-# falls back to a no-flock write (zsh-z.plugin.zsh:227, ~315-321). Single-
-# process correctness must still hold; concurrent updates can race in this
-# mode, which is fundamental, not a regression.
+# `ZSHZ[USE_FLOCK]=0` fallback path: when `zsh/system` isn't available,
+# `_zshz_add_or_remove_path` skips the lockfile path and writes without flock.
+# Single-process add/remove behavior must still hold; concurrent updates can
+# race in this mode by design.
 
 test_add_works_without_flock() {
   ZSHZ[USE_FLOCK]=0

--- a/tests/test_no_flock.zsh
+++ b/tests/test_no_flock.zsh
@@ -1,0 +1,28 @@
+# ZSHZ[USE_FLOCK]=0 fallback path: when zsh/system isn't available, Zsh-z
+# falls back to a no-flock write (zsh-z.plugin.zsh:227, ~315-321). Single-
+# process correctness must still hold; concurrent updates can race in this
+# mode, which is fundamental, not a regression.
+
+test_add_works_without_flock() {
+  ZSHZ[USE_FLOCK]=0
+  zshz --add "$TESTDIR" || return 1
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR")" "--add should work without flock"
+}
+
+test_remove_works_without_flock() {
+  mkdir -p "$TESTDIR/keep" "$TESTDIR/gone"
+  ZSHZ[USE_FLOCK]=0
+  zshz --add "$TESTDIR/keep"
+  zshz --add "$TESTDIR/gone"
+  zshz -x "$TESTDIR/gone"
+  assert_ne "" "$(zshz_rank_of "$TESTDIR/keep")" "kept entry should remain"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/gone")" "removed entry should be gone"
+}
+
+test_no_lockfile_created_without_flock() {
+  ZSHZ[USE_FLOCK]=0
+  zshz --add "$TESTDIR"
+  if [[ -f "${ZSHZ_DATA}.lock" ]]; then
+    fail "lockfile should not be created when USE_FLOCK=0"
+  fi
+}

--- a/tests/test_owner.zsh
+++ b/tests/test_owner.zsh
@@ -1,0 +1,49 @@
+# ZSHZ_OWNER / sudo -s ownership behavior.
+#
+# When ZSHZ_OWNER is set (the documented `sudo -s` workflow), Zsh-z chowns the
+# datafile back to that owner after every successful write. The lockfile at
+# ${datafile}.lock must get the same treatment: zsystem flock opens it O_RDWR,
+# so if root creates it first under sudo and the unprivileged $ZSHZ_OWNER
+# user's subsequent flocks fail with EACCES, the error is swallowed by
+# `2> /dev/null || return` and --add / -x silently do nothing.
+#
+# We can't fabricate two real UIDs in CI, so instead we replace ${ZSHZ[CHOWN]}
+# with a logger and assert that the chown call covers both files together.
+
+test_owner_set_chowns_both_datafile_and_lockfile() {
+  (( ZSHZ[USE_FLOCK] )) || return 0  # No lockfile when flock is unavailable.
+
+  local chown_log="$TESTDIR/chown.log"
+  : > "$chown_log"
+
+  ZSHZ[CHOWN]=_test_log_chown
+  _test_log_chown() { print -- "$@" >> "$chown_log"; }
+
+  local sub="$TESTDIR/sub"
+  mkdir -p "$sub"
+  ZSHZ_OWNER=$(id -un) zshz --add "$sub"
+
+  local logged
+  logged=$(< "$chown_log")
+  assert_contains "$ZSHZ_DATA ${ZSHZ_DATA}.lock" "$logged" \
+    "chown must cover datafile and lockfile together when ZSHZ_OWNER is set"
+}
+
+test_owner_unset_does_not_chown() {
+  (( ZSHZ[USE_FLOCK] )) || return 0
+
+  local chown_log="$TESTDIR/chown.log"
+  : > "$chown_log"
+
+  ZSHZ[CHOWN]=_test_log_chown
+  _test_log_chown() { print -- "$@" >> "$chown_log"; }
+
+  local sub="$TESTDIR/sub"
+  mkdir -p "$sub"
+  unset ZSHZ_OWNER _Z_OWNER
+  zshz --add "$sub"
+
+  assert_eq "" "$(< "$chown_log")" \
+    "no chown should fire when ZSHZ_OWNER is unset"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_permissions.zsh
+++ b/tests/test_permissions.zsh
@@ -1,0 +1,118 @@
+# Datafile permission hardening (#92).
+#
+# `~/.z` must always end up at mode 0600 so a multi-user host can't read
+# another user's directory history. The plugin enforces this by chmodding
+# the file on initial creation and chmodding every tempfile before the
+# rename that replaces `.z'. These tests cover all the write paths that
+# could leak permissions: fresh creation, `--add' over a preexisting
+# 0644 file, `-x' (the remove branch), and the `ZSHZ_OWNER' initial-
+# creation chown that hands `.z' off to the right user under `sudo -s'.
+#
+# MSYS2 deliberately no-ops chmod (Windows filesystems don't honor
+# POSIX modes), so the mode-checking tests skip there.
+
+# Octal regular-permission bits of $1 (e.g. "600"). Returns empty if the
+# `zsh/stat' module isn't loadable. Uses `8#777' rather than `0777' because
+# zsh treats `0777' as decimal 777 without `setopt OCTAL_ZEROES'.
+_test_mode_of() {
+  zmodload -F zsh/stat b:zstat 2>/dev/null
+  (( ${+builtins[zstat]} )) || return
+  local m
+  m=$(zstat -L +mode "$1") || return
+  printf '%03o\n' $(( m & 8#777 ))
+}
+
+# Skip mode-checking tests on platforms where chmod is intentionally a
+# no-op or where zsh/stat is unavailable. Returns 0 (skip) or 1 (run).
+_test_skip_mode_check() {
+  [[ $OSTYPE == msys ]] && return 0
+  zmodload -F zsh/stat b:zstat 2>/dev/null
+  (( ${+builtins[zstat]} )) || return 0
+  return 1
+}
+
+test_initial_creation_is_0600() {
+  _test_skip_mode_check && return 0
+
+  rm -f "$ZSHZ_DATA"
+  zshz -l
+  assert_file_exists "$ZSHZ_DATA"
+  assert_eq "600" "$(_test_mode_of "$ZSHZ_DATA")" \
+    "fresh .z must be created at mode 0600"
+}
+
+test_add_clamps_preexisting_world_readable_file_to_0600() {
+  _test_skip_mode_check && return 0
+
+  : > "$ZSHZ_DATA" && chmod 644 "$ZSHZ_DATA"
+  assert_eq "644" "$(_test_mode_of "$ZSHZ_DATA")" "precondition: file is 0644"
+
+  mkdir -p "$TESTDIR/work"
+  zshz --add "$TESTDIR/work" || return 1
+  assert_eq "600" "$(_test_mode_of "$ZSHZ_DATA")" \
+    "--add must clamp a preexisting 0644 .z to 0600 via the tempfile rename"
+}
+
+test_remove_keeps_0600() {
+  _test_skip_mode_check && return 0
+
+  local d="$TESTDIR/r"
+  mkdir -p "$d"
+  zshz --add "$d" || return 1
+  zshz -x "$d" || return 1
+  assert_eq "600" "$(_test_mode_of "$ZSHZ_DATA")" \
+    "-x must leave .z at mode 0600 after the rewrite"
+}
+
+test_repeated_writes_keep_0600() {
+  # Each --add rewrites the datafile via a fresh tempfile. Loosening
+  # permissions on any single write would defeat the protection, so
+  # walk a handful of writes and assert after each one.
+  _test_skip_mode_check && return 0
+
+  local i d
+  for i in 1 2 3 4 5; do
+    d="$TESTDIR/d$i"
+    mkdir -p "$d"
+    zshz --add "$d" || return 1
+    assert_eq "600" "$(_test_mode_of "$ZSHZ_DATA")" \
+      "iteration $i: .z must remain at mode 0600 after every --add"
+  done
+}
+
+test_initial_creation_chowns_when_ZSHZ_OWNER_set() {
+  # Under `sudo -s' with ZSHZ_OWNER=user, a query-only `z foo' would
+  # otherwise leave a root-owned .z behind that the normal-user shell
+  # can't read. The create path therefore chowns to ZSHZ_OWNER eagerly,
+  # without waiting for a write to happen. We can't fabricate two UIDs
+  # in CI, so we stub ${ZSHZ[CHOWN]} and assert the call shape.
+  local chown_log="$TESTDIR/chown.log"
+  : > "$chown_log"
+
+  ZSHZ[CHOWN]=_test_log_chown
+  _test_log_chown() { print -- "$@" >> "$chown_log"; }
+
+  rm -f "$ZSHZ_DATA"
+  ZSHZ_OWNER=$(id -un) zshz -l
+
+  local logged
+  logged=$(< "$chown_log")
+  assert_contains "$ZSHZ_DATA" "$logged" \
+    "initial creation must chown the datafile when ZSHZ_OWNER is set"
+}
+
+test_initial_creation_does_not_chown_when_ZSHZ_OWNER_unset() {
+  local chown_log="$TESTDIR/chown.log"
+  : > "$chown_log"
+
+  ZSHZ[CHOWN]=_test_log_chown
+  _test_log_chown() { print -- "$@" >> "$chown_log"; }
+
+  rm -f "$ZSHZ_DATA"
+  unset ZSHZ_OWNER _Z_OWNER
+  zshz -l
+
+  assert_eq "" "$(< "$chown_log")" \
+    "no chown should fire on initial creation when ZSHZ_OWNER is unset"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_permissions.zsh
+++ b/tests/test_permissions.zsh
@@ -1,15 +1,20 @@
 # Datafile permission hardening (#92).
 #
 # `~/.z` must always end up at mode 0600 so a multi-user host can't read
-# another user's directory history. The plugin enforces this by chmodding
-# the file on initial creation and chmodding every tempfile before the
-# rename that replaces `.z'. These tests cover all the write paths that
-# could leak permissions: fresh creation, `--add' over a preexisting
-# 0644 file, `-x' (the remove branch), and the `ZSHZ_OWNER' initial-
-# creation chown that hands `.z' off to the right user under `sudo -s'.
+# another user's directory history. The plugin enforces this by setting
+# `umask 077' around the file-creation steps (the initial `touch' of
+# `.z' and every fresh tempfile), so each file is born at 0600 without
+# a follow-up chmod -- `mv' then atomically replaces `.z' with the
+# tempfile and preserves its 0600. These tests cover all the write
+# paths that could leak permissions: fresh creation, `--add' over a
+# preexisting 0644 file, `-x' (the remove branch), and the `ZSHZ_OWNER'
+# initial-creation chown that hands `.z' off to the right user under
+# `sudo -s'. A separate test pins the umask save/restore contract so
+# the writer can't permanently change the caller's umask.
 #
-# MSYS2 deliberately no-ops chmod (Windows filesystems don't honor
-# POSIX modes), so the mode-checking tests skip there.
+# MSYS2's filesystem semantics don't reliably reflect POSIX modes
+# (Windows ACLs are the source of truth there), so the mode-checking
+# tests skip on msys.
 
 # Octal regular-permission bits of $1 (e.g. "600"). Returns empty if the
 # `zsh/stat' module isn't loadable. Uses `8#777' rather than `0777' because
@@ -22,8 +27,8 @@ _test_mode_of() {
   printf '%03o\n' $(( m & 8#777 ))
 }
 
-# Skip mode-checking tests on platforms where chmod is intentionally a
-# no-op or where zsh/stat is unavailable. Returns 0 (skip) or 1 (run).
+# Skip mode-checking tests on platforms where POSIX modes are unreliable
+# (msys) or where zsh/stat is unavailable. Returns 0 (skip) or 1 (run).
 _test_skip_mode_check() {
   [[ $OSTYPE == msys ]] && return 0
   zmodload -F zsh/stat b:zstat 2>/dev/null
@@ -114,5 +119,25 @@ test_initial_creation_does_not_chown_when_ZSHZ_OWNER_unset() {
 
   assert_eq "" "$(< "$chown_log")" \
     "no chown should fire on initial creation when ZSHZ_OWNER is unset"
+}
+
+test_umask_restored_after_zshz() {
+  # The plugin temporarily sets umask 077 to birth .z and tempfiles at
+  # 0600. It must restore the caller's umask before returning -- a leak
+  # would leave the user's shell creating subsequent files at 0700/dir
+  # and 0600/file for the rest of the session, which the user would
+  # eventually notice but couldn't easily trace back to zsh-z. Cover
+  # both the initial-creation umask juggling and the writer block's
+  # `{ ... } always { umask ... }' restore.
+  umask 022
+  local before=$(umask)
+
+  rm -f "$ZSHZ_DATA"  # forces the initial-creation path
+  mkdir -p "$TESTDIR/work"
+  zshz --add "$TESTDIR/work" || return 1
+  assert_eq "$before" "$(umask)" "umask must be restored after zshz --add"
+
+  zshz -x "$TESTDIR/work" || return 1
+  assert_eq "$before" "$(umask)" "umask must be restored after zshz -x"
 }
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_permissions.zsh
+++ b/tests/test_permissions.zsh
@@ -121,6 +121,42 @@ test_initial_creation_does_not_chown_when_ZSHZ_OWNER_unset() {
     "no chown should fire on initial creation when ZSHZ_OWNER is unset"
 }
 
+test_umask_unchanged_when_initial_touch_fails() {
+  # Pins the subshell scoping of the initial-creation block: `umask 077'
+  # runs inside `( ... )' so a failed touch (or any other abnormal exit)
+  # can't leave the caller's shell stuck at 077. Stub touch to fail and
+  # confirm the parent's umask is untouched.
+  #
+  # A regression that inlines the umask change in the parent (e.g.
+  # `umask 077; touch; umask "$saved"') would leak here, since touch
+  # fails between the two umask calls.
+  #
+  # Skipped on zsh 4.3.11: there `$(< /missing)' kills the whole shell
+  # rather than just returning empty, so the follow-on datafile read
+  # exits the test subshell before the umask assertion runs. Modern
+  # zsh has the same contract and is enough to catch the regression.
+  is-at-least 5 || { print "skip: zsh < 5"; return 0 }
+
+  umask 022
+  local before=$(umask)
+
+  # Stub touch to abort instead of just returning non-zero: the subshell
+  # scoping must contain a hard exit too. With the unhardened inline form,
+  # `umask 077; touch (exits); umask "$saved"' never reaches the restore
+  # and the caller's umask leaks. With the subshell form, the exit is
+  # confined to `( ... )' and the parent's umask is untouched.
+  function touch { exit 1; }
+  rm -f "$ZSHZ_DATA"
+  # zshz will fail to read the datafile that touch refused to create; the
+  # ensuing "no such file" is expected here, drop it on the floor so the
+  # runner's no-stderr policy doesn't fail the test.
+  zshz -l 2>/dev/null
+  unfunction touch
+
+  assert_eq "$before" "$(umask)" \
+    "umask must survive a touch failure during initial creation"
+}
+
 test_umask_restored_after_zshz() {
   # The plugin temporarily sets umask 077 to birth .z and tempfiles at
   # 0600. It must restore the caller's umask before returning -- a leak

--- a/tests/test_permissions.zsh
+++ b/tests/test_permissions.zsh
@@ -137,6 +137,13 @@ test_umask_unchanged_when_initial_touch_fails() {
   # zsh has the same contract and is enough to catch the regression.
   is-at-least 5 || { print "skip: zsh < 5"; return 0 }
 
+  # Skipped when ZSHZ[CHMOD] is set: that path uses `touch && zf_chmod'
+  # without an umask change, so there is no umask-leak contract to pin
+  # and the `touch { exit 1 }' stub below would just kill the test
+  # shell. The contract this test exists for only applies to the
+  # umask fallback used when zf_chmod is unavailable.
+  [[ -n ${ZSHZ[CHMOD]:-} ]] && { print "skip: chmod path (no umask change to leak)"; return 0 }
+
   umask 022
   local before=$(umask)
 

--- a/tests/test_permissions.zsh
+++ b/tests/test_permissions.zsh
@@ -1,16 +1,14 @@
 # Datafile permission hardening (#92).
 #
 # `~/.z` must always end up at mode 0600 so a multi-user host can't read
-# another user's directory history. The plugin enforces this by setting
-# `umask 077' around the file-creation steps (the initial `touch' of
-# `.z' and every fresh tempfile), so each file is born at 0600 without
-# a follow-up chmod -- `mv' then atomically replaces `.z' with the
-# tempfile and preserves its 0600. These tests cover all the write
-# paths that could leak permissions: fresh creation, `--add' over a
-# preexisting 0644 file, `-x' (the remove branch), and the `ZSHZ_OWNER'
-# initial-creation chown that hands `.z' off to the right user under
-# `sudo -s'. A separate test pins the umask save/restore contract so
-# the writer can't permanently change the caller's umask.
+# another user's directory history. The plugin enforces this by calling
+# `${ZSHZ[CHMOD]} 600' after every file creation -- the in-process
+# `zf_chmod' on Zsh 5+ and the external `chmod' on Zsh 4.3.11. `mv'
+# then atomically replaces `.z' with the tempfile and preserves its
+# 0600. These tests cover all the write paths that could leak
+# permissions: fresh creation, `--add' over a preexisting 0644 file,
+# `-x' (the remove branch), and the `ZSHZ_OWNER' initial-creation
+# chown that hands `.z' off to the right user under `sudo -s'.
 #
 # MSYS2's filesystem semantics don't reliably reflect POSIX modes
 # (Windows ACLs are the source of truth there), so the mode-checking
@@ -130,66 +128,4 @@ test_initial_creation_does_not_chown_when_ZSHZ_OWNER_unset() {
     "no chown should fire on initial creation when ZSHZ_OWNER is unset"
 }
 
-test_umask_unchanged_when_initial_touch_fails() {
-  # Pins the subshell scoping of the initial-creation block: `umask 077'
-  # runs inside `( ... )' so a failed touch (or any other abnormal exit)
-  # can't leave the caller's shell stuck at 077. Stub touch to fail and
-  # confirm the parent's umask is untouched.
-  #
-  # A regression that inlines the umask change in the parent (e.g.
-  # `umask 077; touch; umask "$saved"') would leak here, since touch
-  # fails between the two umask calls.
-  #
-  # Skipped on zsh 4.3.11: there `$(< /missing)' kills the whole shell
-  # rather than just returning empty, so the follow-on datafile read
-  # exits the test subshell before the umask assertion runs. Modern
-  # zsh has the same contract and is enough to catch the regression.
-  is-at-least 5 || { print "skip: zsh < 5"; return 0 }
-
-  # Skipped when ZSHZ[CHMOD] is set: that path uses `touch && zf_chmod'
-  # without an umask change, so there is no umask-leak contract to pin
-  # and the `touch { exit 1 }' stub below would just kill the test
-  # shell. The contract this test exists for only applies to the
-  # umask fallback used when zf_chmod is unavailable.
-  [[ -n ${ZSHZ[CHMOD]:-} ]] && { print "skip: chmod path (no umask change to leak)"; return 0 }
-
-  umask 022
-  local before=$(umask)
-
-  # Stub touch to abort instead of just returning non-zero: the subshell
-  # scoping must contain a hard exit too. With the unhardened inline form,
-  # `umask 077; touch (exits); umask "$saved"' never reaches the restore
-  # and the caller's umask leaks. With the subshell form, the exit is
-  # confined to `( ... )' and the parent's umask is untouched.
-  function touch { exit 1; }
-  rm -f "$ZSHZ_DATA"
-  # zshz will fail to read the datafile that touch refused to create; the
-  # ensuing "no such file" is expected here, drop it on the floor so the
-  # runner's no-stderr policy doesn't fail the test.
-  zshz -l 2>/dev/null
-  unfunction touch
-
-  assert_eq "$before" "$(umask)" \
-    "umask must survive a touch failure during initial creation"
-}
-
-test_umask_restored_after_zshz() {
-  # The plugin temporarily sets umask 077 to birth .z and tempfiles at
-  # 0600. It must restore the caller's umask before returning -- a leak
-  # would leave the user's shell creating subsequent files at 0700/dir
-  # and 0600/file for the rest of the session, which the user would
-  # eventually notice but couldn't easily trace back to zsh-z. Cover
-  # both the initial-creation umask juggling and the writer block's
-  # `{ ... } always { umask ... }' restore.
-  umask 022
-  local before=$(umask)
-
-  rm -f "$ZSHZ_DATA"  # forces the initial-creation path
-  mkdir -p "$TESTDIR/work"
-  zshz --add "$TESTDIR/work" || return 1
-  assert_eq "$before" "$(umask)" "umask must be restored after zshz --add"
-
-  zshz -x "$TESTDIR/work" || return 1
-  assert_eq "$before" "$(umask)" "umask must be restored after zshz -x"
-}
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_permissions.zsh
+++ b/tests/test_permissions.zsh
@@ -27,12 +27,21 @@ _test_mode_of() {
   printf '%03o\n' $(( m & 8#777 ))
 }
 
-# Skip mode-checking tests on platforms where POSIX modes are unreliable
-# (msys) or where zsh/stat is unavailable. Returns 0 (skip) or 1 (run).
+# Skip mode-checking tests when zsh/stat is unavailable or when the
+# underlying filesystem ignores POSIX mode bits. The latter check is a
+# probe rather than an $OSTYPE match because MSYS2 reports
+# $OSTYPE=cygwin but (unlike real Cygwin) silently ignores chmod on its
+# Windows-backed filesystem; probing chmod's actual effect handles both
+# cases without false-skipping on platforms that do honor modes.
+# Returns 0 (skip) or 1 (run).
 _test_skip_mode_check() {
-  [[ $OSTYPE == msys ]] && return 0
   zmodload -F zsh/stat b:zstat 2>/dev/null
   (( ${+builtins[zstat]} )) || return 0
+  local probe=$TESTDIR/.mode-probe m
+  : > "$probe" && chmod 600 "$probe" 2>/dev/null
+  m=$(zstat -L +mode "$probe" 2>/dev/null)
+  rm -f "$probe"
+  (( (m & 8#777) == 8#600 )) || return 0
   return 1
 }
 

--- a/tests/test_resource.zsh
+++ b/tests/test_resource.zsh
@@ -1,0 +1,63 @@
+# Re-sourcing safety and Tab-binding behavior.
+#
+# When the plugin is sourced, it captures the current Tab binding into
+# ZSHZ[TAB_BINDING] so its own widget can chain to it. If sourced a second
+# time it must NOT recapture, or it would record its own widget name and
+# cause infinite recursion when Tab is pressed (see commit 62569dd).
+#
+# Each test runs in a fresh `zsh --no-rcs -c` subshell so the plugin is being
+# sourced for the first time in that process.
+
+test_first_source_captures_existing_tab_binding() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    print -- \$ZSHZ[TAB_BINDING]
+  ")
+  assert_eq "expand-or-complete" "$out" "TAB_BINDING should hold the prior binding"
+}
+
+test_first_source_binds_tab_to_widget() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    bindkey -M main '^I'
+  ")
+  assert_contains "_zshz_zle_completion_widget" "$out" "Tab should be bound to the widget after sourcing"
+}
+
+test_resource_does_not_capture_own_widget() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    print -- \$ZSHZ[TAB_BINDING]
+  ")
+  assert_ne "_zshz_zle_completion_widget" "$out" "re-source must not capture its own widget"
+  assert_eq "expand-or-complete" "$out" "TAB_BINDING should still be the original binding"
+}
+
+test_resource_keeps_tab_bound_to_widget() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    bindkey -M main '^I'
+  ")
+  assert_contains "_zshz_zle_completion_widget" "$out" "Tab should still be bound to the widget after re-source"
+}
+
+test_first_source_preserves_non_default_tab_binding() {
+  local out
+  out=$(zsh --no-rcs -c "
+    autoload -U menu-complete; zle -N menu-complete
+    bindkey -M main '^I' menu-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    print -- \$ZSHZ[TAB_BINDING]
+  ")
+  assert_eq "menu-complete" "$out" "user's non-default Tab binding should be captured verbatim"
+}

--- a/tests/test_resource.zsh
+++ b/tests/test_resource.zsh
@@ -49,3 +49,4 @@ test_first_source_preserves_non_default_tab_binding() {
   ")
   assert_eq "menu-complete" "$out" "user's non-default Tab binding should be captured verbatim"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_resource.zsh
+++ b/tests/test_resource.zsh
@@ -9,30 +9,17 @@
 # sourced for the first time in that process.
 
 test_first_source_captures_existing_tab_binding() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
-    print -- \$ZSHZ[TAB_BINDING]
-  ")
+  local out=$(zshz_in_fresh_shell 'print -- $ZSHZ[TAB_BINDING]')
   assert_eq "expand-or-complete" "$out" "TAB_BINDING should hold the prior binding"
 }
 
 test_first_source_binds_tab_to_widget() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
-    bindkey -M main '^I'
-  ")
+  local out=$(zshz_in_fresh_shell "bindkey -M main '^I'")
   assert_contains "_zshz_zle_completion_widget" "$out" "Tab should be bound to the widget after sourcing"
 }
 
 test_resource_does_not_capture_own_widget() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     source '$PLUGIN_DIR/zsh-z.plugin.zsh'
     print -- \$ZSHZ[TAB_BINDING]
   ")
@@ -41,10 +28,7 @@ test_resource_does_not_capture_own_widget() {
 }
 
 test_resource_keeps_tab_bound_to_widget() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     source '$PLUGIN_DIR/zsh-z.plugin.zsh'
     bindkey -M main '^I'
   ")

--- a/tests/test_resource.zsh
+++ b/tests/test_resource.zsh
@@ -9,17 +9,20 @@
 # sourced for the first time in that process.
 
 test_first_source_captures_existing_tab_binding() {
-  local out=$(zshz_in_fresh_shell 'print -- $ZSHZ[TAB_BINDING]')
+  local out
+  out=$(zshz_in_fresh_shell 'print -- $ZSHZ[TAB_BINDING]')
   assert_eq "expand-or-complete" "$out" "TAB_BINDING should hold the prior binding"
 }
 
 test_first_source_binds_tab_to_widget() {
-  local out=$(zshz_in_fresh_shell "bindkey -M main '^I'")
+  local out
+  out=$(zshz_in_fresh_shell "bindkey -M main '^I'")
   assert_contains "_zshz_zle_completion_widget" "$out" "Tab should be bound to the widget after sourcing"
 }
 
 test_resource_does_not_capture_own_widget() {
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     source '$PLUGIN_DIR/zsh-z.plugin.zsh'
     print -- \$ZSHZ[TAB_BINDING]
   ")
@@ -28,7 +31,8 @@ test_resource_does_not_capture_own_widget() {
 }
 
 test_resource_keeps_tab_bound_to_widget() {
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     source '$PLUGIN_DIR/zsh-z.plugin.zsh'
     bindkey -M main '^I'
   ")

--- a/tests/test_scale.zsh
+++ b/tests/test_scale.zsh
@@ -1,0 +1,107 @@
+# Scale / smoke tests for large datafiles.
+#
+# Gated behind ZSHZ_HEAVY_TESTS=1 so the regular run stays fast. These
+# tests exercise the read+filter+rewrite code paths against datafiles
+# orders of magnitude larger than typical interactive use, to catch
+# accidental quadratic blowups, memory issues, or array-handling bugs
+# that only surface at scale. Aging *correctness* at the threshold is
+# already covered by test_aging.zsh; this file targets behavior under
+# load.
+#
+# Run with:  ZSHZ_HEAVY_TESTS=1 zsh tests/run.zsh 'test_large_*'
+
+[[ -n $ZSHZ_HEAVY_TESTS ]] || return 0
+
+# Seed $1 entries directly into $ZSHZ_DATA in a single redirected block
+# (no per-entry fork; calling `zshz_seed' in a loop is much slower).
+# Each entry gets a unique path under $TESTDIR/scale/dir_$i.
+_seed_n_entries() {
+  local n=$1 i
+  local now=$EPOCHSECONDS
+  {
+    for ((i=1; i<=n; i++)); do
+      print "$TESTDIR/scale/dir_$i|$i|$(( now - i ))"
+    done
+  } > "$ZSHZ_DATA"
+}
+
+test_large_datafile_list_completes() {
+  local n=5000
+  _seed_n_entries $n
+  # Both the read-time `_zshz_find_matches' loop and the write-time
+  # `_zshz_update_datafile' loop drop entries whose backing directory
+  # doesn't exist. KEEP_DIRS=/ preserves them all.
+  ZSHZ_KEEP_DIRS=( / )
+
+  local out lines
+  out=$(zshz -l)
+  lines=$(print -r -- "$out" | wc -l)
+
+  (( lines >= n - 100 )) || \
+    fail "list output truncated; expected ~$n lines, got $lines"
+}
+
+test_large_datafile_add_preserves_entries() {
+  local n=5000
+  _seed_n_entries $n
+  ZSHZ_KEEP_DIRS=( / )
+  # Push MAX_SCORE far above the seeded sum (sum of 1..n = n*(n+1)/2 =
+  # 12502500) so aging doesn't kick in here -- this test is about
+  # scale-time correctness of the rewrite path, not aging arithmetic.
+  ZSHZ_MAX_SCORE=99999999
+  mkdir -p "$TESTDIR/new"
+
+  zshz --add "$TESTDIR/new" || return 1
+
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/new")" \
+    "--add to a large datafile should land the new entry"
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/scale/dir_1")" \
+    "first seeded entry should survive --add through a large datafile"
+  assert_eq "$n" "$(zshz_rank_of "$TESTDIR/scale/dir_$n")" \
+    "last seeded entry should survive --add through a large datafile"
+}
+
+test_large_datafile_search_returns_a_match() {
+  local n=5000
+  _seed_n_entries $n
+  ZSHZ_KEEP_DIRS=( / )
+  # Real directory so the echo path can produce output.
+  mkdir -p "$TESTDIR/scale/dir_4242"
+
+  local out
+  out=$(zshz -e dir_4242)
+  assert_contains "dir_4242" "$out" \
+    "search through a large datafile should find the matching entry"
+}
+
+test_large_datafile_aging_triggers_at_scale() {
+  # With ranks 1..n, sum = n*(n+1)/2 -- 12502500 for n=5000, far above
+  # the default MAX_SCORE of 9000. The next --add should multiply every
+  # rank by 0.99. We assert this on a few sampled entries; doing so
+  # across 5000 also exercises the aging loop's behavior on a real
+  # large dataset.
+  local n=5000
+  _seed_n_entries $n
+  ZSHZ_KEEP_DIRS=( / )
+  # --add an existing entry so the test doesn't depend on `mkdir' for
+  # the new path; we want to observe aging on entries already present.
+  mkdir -p "$TESTDIR/scale/dir_1"
+
+  zshz --add "$TESTDIR/scale/dir_1" || return 1
+
+  # dir_1 starts at rank 1, becomes 2 after the add, then aging
+  # multiplies by 0.99 -> 1.98. Allow some slack for floating-point
+  # representation.
+  local r1
+  r1=$(zshz_rank_of "$TESTDIR/scale/dir_1")
+  [[ -n $r1 ]] || fail "dir_1 should still exist after aging"
+  (( r1 < 2 ))    || fail "aging should drop dir_1 below 2, was $r1"
+  (( r1 > 1.9 )) || fail "aging shouldn't drop dir_1 below 1.9, was $r1"
+
+  # dir_5000 stays at rank 5000 (it wasn't re-added), aged to 4950.
+  local rN
+  rN=$(zshz_rank_of "$TESTDIR/scale/dir_$n")
+  (( rN < 5000 )) || fail "aging should drop dir_$n below 5000, was $rN"
+  (( rN > 4940 )) || fail "aging shouldn't drop dir_$n below 4940, was $rN"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_special_chars.zsh
+++ b/tests/test_special_chars.zsh
@@ -1,0 +1,131 @@
+# Round-trip behaviour for paths containing characters that are special to
+# the shell, glob engine, or both. Exercises the `${(q)2}' quoting in
+# `_zshz_update_datafile' and the escape list in `_zshz_find_matches'.
+#
+# Each test creates a real directory (so the missing-directory prune
+# doesn't drop the entry), `--add's it, verifies the entry is reachable
+# via `zshz -e <substring>' and visible in `zshz -l', then removes it
+# with `zshz -x' and confirms it's gone.
+
+test_path_with_spaces_round_trip() {
+  local p="$TESTDIR/has spaces/inner"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with spaces"
+
+  local out
+  out=$(zshz -e spaces)
+  assert_eq "$p" "$out" "search should find path with spaces"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear path with spaces"
+}
+
+test_path_with_brackets_round_trip() {
+  local p="$TESTDIR/has[brackets]/inner"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with []"
+
+  local out
+  out=$(zshz -e brackets)
+  assert_eq "$p" "$out" "search should find path with []"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear path with []"
+}
+
+test_path_with_star_round_trip() {
+  local p="$TESTDIR/has*star/inner"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with *"
+
+  local out
+  out=$(zshz -e star)
+  assert_eq "$p" "$out" "search should find path with *"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear path with *"
+}
+
+test_path_with_question_mark_round_trip() {
+  local p="$TESTDIR/has?question/inner"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with ?"
+
+  local out
+  out=$(zshz -e question)
+  assert_eq "$p" "$out" "search should find path with ?"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear path with ?"
+}
+
+test_path_with_backtick_round_trip() {
+  local p="$TESTDIR"'/has`backtick/inner'
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with backtick"
+
+  local out
+  out=$(zshz -e backtick)
+  assert_eq "$p" "$out" "search should find path with backtick"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear path with backtick"
+}
+
+test_path_with_single_quote_round_trip() {
+  local p="$TESTDIR/has'quote/inner"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with single quote"
+
+  local out
+  out=$(zshz -e quote)
+  assert_eq "$p" "$out" "search should find path with single quote"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear path with single quote"
+}
+
+test_path_with_dollar_sign_add_and_remove() {
+  # KNOWN-BUG: paths containing `$' currently round-trip through `--add'
+  # and `-x', but `zshz -l' and `zshz -e' don't see them.
+  #
+  # `_zshz_find_matches' assigns `matches[$path_field]=$rank' (a normal
+  # parameter expansion, fine) and then later checks the same entry via
+  # `(( matches[$escaped_path_field] ))'. That lookup runs in math
+  # context, where zsh re-expands `$' inside the subscript -- so a
+  # subscript like `/tmp/has$dollar' becomes `/tmp/has' (with $dollar
+  # unset). The lookup misses, `best_match' stays empty, and
+  # `_zshz_find_matches' returns 1 -- so `_zshz_output' is never called
+  # at all when the dollar entry is the only candidate. The plugin's
+  # `escaped_path_field' block (\, `, (, ), [, ]) doesn't currently
+  # include `$'. Once it does, the search/list assertions from the
+  # other tests in this file should be added here too.
+  local p="$TESTDIR"'/has$dollar/inner'
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with \$"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear path with \$"
+}
+
+test_path_with_mixed_special_chars_add_and_remove() {
+  # Same `$'-in-math-context limitation as the dollar-sign test: the
+  # path here also contains `$', so `zshz -l'/`zshz -e' won't surface
+  # it on its own. We just check that the quoting machinery round-trips
+  # add and remove without corrupting the datafile.
+  local p="$TESTDIR"'/mixed [abc] $var `tick` *star ?q '"'q'/inner"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with mixed special chars"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear the mixed-specials entry"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_special_chars.zsh
+++ b/tests/test_special_chars.zsh
@@ -91,39 +91,33 @@ test_path_with_single_quote_round_trip() {
   assert_eq "" "$(zshz_rank_of "$p")" "remove should clear path with single quote"
 }
 
-test_path_with_dollar_sign_add_and_remove() {
-  # KNOWN-BUG: paths containing `$' currently round-trip through `--add'
-  # and `-x', but `zshz -l' and `zshz -e' don't see them.
-  #
-  # `_zshz_find_matches' assigns `matches[$path_field]=$rank' (a normal
-  # parameter expansion, fine) and then later checks the same entry via
-  # `(( matches[$escaped_path_field] ))'. That lookup runs in math
-  # context, where zsh re-expands `$' inside the subscript -- so a
-  # subscript like `/tmp/has$dollar' becomes `/tmp/has' (with $dollar
-  # unset). The lookup misses, `best_match' stays empty, and
-  # `_zshz_find_matches' returns 1 -- so `_zshz_output' is never called
-  # at all when the dollar entry is the only candidate. The plugin's
-  # `escaped_path_field' block (\, `, (, ), [, ]) doesn't currently
-  # include `$'. Once it does, the search/list assertions from the
-  # other tests in this file should be added here too.
+test_path_with_dollar_sign_round_trip() {
   local p="$TESTDIR"'/has$dollar/inner'
   mkdir -p "$p"
   zshz --add "$p"
   assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with \$"
 
+  local out
+  out=$(zshz -e dollar)
+  assert_eq "$p" "$out" "search should find path with \$"
+
   zshz -x "$p"
   assert_eq "" "$(zshz_rank_of "$p")" "remove should clear path with \$"
 }
 
-test_path_with_mixed_special_chars_add_and_remove() {
-  # Same `$'-in-math-context limitation as the dollar-sign test: the
-  # path here also contains `$', so `zshz -l'/`zshz -e' won't surface
-  # it on its own. We just check that the quoting machinery round-trips
-  # add and remove without corrupting the datafile.
+test_path_with_mixed_special_chars_round_trip() {
+  # All seven special chars in one path. We search by a substring that
+  # avoids the chars themselves so the search-side glob doesn't have
+  # to deal with them -- this test pins the *quoting* round-trip, not
+  # the search-side handling of every meta in a query.
   local p="$TESTDIR"'/mixed [abc] $var `tick` *star ?q '"'q'/inner"
   mkdir -p "$p"
   zshz --add "$p"
   assert_eq "1" "$(zshz_rank_of "$p")" "add should land path with mixed special chars"
+
+  local out
+  out=$(zshz -e mixed)
+  assert_eq "$p" "$out" "search should find the mixed-specials entry"
 
   zshz -x "$p"
   assert_eq "" "$(zshz_rank_of "$p")" "remove should clear the mixed-specials entry"

--- a/tests/test_strict_options.zsh
+++ b/tests/test_strict_options.zsh
@@ -1,0 +1,65 @@
+# Sourcing the plugin under strict zsh options.
+#
+# Some users put `setopt NO_UNSET WARN_CREATE_GLOBAL NO_NOMATCH' (or
+# variants) in their .zshrc to catch sloppy scripting. The plugin
+# already explicitly guards `_zshz_precmd' against NO_UNSET (line 967:
+# `setopt LOCAL_OPTIONS UNSET'), but that's only one entry point. This
+# file pins the broader contract: with each of these options active at
+# source time, sourcing the plugin and exercising it must produce
+# zero noise on stderr.
+#
+# The test runner already fails on any non-empty stderr, so we don't
+# need to assert on stderr explicitly -- a regression that emits a
+# warning will surface as a normal test failure.
+
+_zshz_test_zsh_bin() {
+  local bin
+  bin=$(readlink /proc/$$/exe 2>/dev/null)
+  [[ -x $bin ]] && { print -- $bin; return }
+  print -- ${commands[zsh]:-zsh}
+}
+
+_zshz_test_strict_round_trip() {
+  local opts=$1 zsh_bin
+  zsh_bin=$(_zshz_test_zsh_bin)
+  mkdir -p "$TESTDIR/work"
+
+  # The child shell's stderr propagates up to this test's stderr; the
+  # runner fails the test if anything appears there.
+  local out
+  out=$("$zsh_bin" --no-rcs -c "
+    setopt $opts
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zshz --add '$TESTDIR/work'
+    _zshz_precmd
+    # Wait for the disowned precmd write to land.
+    local i
+    for ((i=0; i<40; i++)); do
+      [[ -n \$(awk -F'|' -v p='$TESTDIR/work' '\$1==p { print \$2 }' '$TESTDIR/.z' 2>/dev/null) ]] && break
+      sleep 0.05
+    done
+    zshz -l
+  ")
+  local rc=$?
+
+  assert_eq "0" "$rc" "$opts: round-trip should succeed"
+  assert_contains "$TESTDIR/work" "$out" \
+    "$opts: list output should contain the added path"
+}
+
+test_source_with_NO_UNSET() {
+  _zshz_test_strict_round_trip 'NO_UNSET'
+}
+
+test_source_with_WARN_CREATE_GLOBAL() {
+  _zshz_test_strict_round_trip 'WARN_CREATE_GLOBAL'
+}
+
+test_source_with_NO_NOMATCH() {
+  _zshz_test_strict_round_trip 'NO_NOMATCH'
+}
+
+test_source_with_combined_strict_options() {
+  _zshz_test_strict_round_trip 'NO_UNSET WARN_CREATE_GLOBAL NO_NOMATCH'
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_symlink_realpath.zsh
+++ b/tests/test_symlink_realpath.zsh
@@ -1,0 +1,106 @@
+# Realpath-resolution edge cases for `--add' and `-x'.
+#
+# `_zshz_add_or_remove_path' funnels paths through `:A' (resolve
+# symlinks + dot/dot-dot) when symlink resolution is on, and through
+# `:a' (resolve dot/dot-dot only) when `ZSHZ_NO_RESOLVE_SYMLINKS=1'.
+# These tests cover the cases `test_symlinks.zsh' doesn't reach:
+#
+#   - Two distinct symlinks resolving to the same target. Adding
+#     through one and removing through the other should round-trip.
+#   - Adding through a symlink and removing through the target
+#     directly (and vice versa).
+#   - Chained symlinks (link -> link -> target).
+#   - Paths containing `..' traversal.
+#   - The negative case under `ZSHZ_NO_RESOLVE_SYMLINKS=1', where two
+#     symlinks to the same target are *not* the same key.
+
+test_two_symlinks_to_same_target_share_a_db_entry() {
+  # Default mode resolves symlinks. Adding through link1 and removing
+  # through link2 should both refer to the same canonical entry.
+  local target="$TESTDIR/target/inner"
+  mkdir -p "$target"
+  ln -s "$TESTDIR/target" "$TESTDIR/link1"
+  ln -s "$TESTDIR/target" "$TESTDIR/link2"
+
+  zshz --add "$TESTDIR/link1/inner"
+  assert_eq "1" "$(zshz_rank_of "$target")" \
+    "--add via link1 should store the resolved target"
+
+  zshz -x "$TESTDIR/link2/inner"
+  assert_eq "" "$(zshz_rank_of "$target")" \
+    "-x via link2 should remove the entry added via link1"
+}
+
+test_add_via_symlink_remove_via_target() {
+  local target="$TESTDIR/target/inner"
+  mkdir -p "$target"
+  ln -s "$TESTDIR/target" "$TESTDIR/link"
+
+  zshz --add "$TESTDIR/link/inner"
+  zshz -x "$target"
+  assert_eq "" "$(zshz_rank_of "$target")" \
+    "-x via target path should remove the entry added via symlink"
+}
+
+test_add_via_target_remove_via_symlink() {
+  local target="$TESTDIR/target/inner"
+  mkdir -p "$target"
+  ln -s "$TESTDIR/target" "$TESTDIR/link"
+
+  zshz --add "$target"
+  zshz -x "$TESTDIR/link/inner"
+  assert_eq "" "$(zshz_rank_of "$target")" \
+    "-x via symlink should remove the entry added via target"
+}
+
+test_chained_symlinks_resolve_to_final_target() {
+  # link_outer -> link_inner -> target. `:A' walks the whole chain.
+  local target="$TESTDIR/target/dest"
+  mkdir -p "$target"
+  ln -s "$TESTDIR/target" "$TESTDIR/link_inner"
+  ln -s "$TESTDIR/link_inner" "$TESTDIR/link_outer"
+
+  zshz --add "$TESTDIR/link_outer/dest"
+  assert_eq "1" "$(zshz_rank_of "$target")" \
+    "chained symlinks should resolve to the final target"
+}
+
+test_dotdot_traversal_is_canonicalised() {
+  # `:A' resolves `..' as well as symlinks. `--add foo/../foo/bar'
+  # should land in the database as `foo/bar'.
+  mkdir -p "$TESTDIR/foo/bar"
+  zshz --add "$TESTDIR/foo/../foo/bar"
+
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/foo/bar")" \
+    "dot-dot traversal should be collapsed in the stored path"
+  # The literal traversal form must NOT appear in the database.
+  local dump
+  dump=$(zshz_dump)
+  assert_not_contains ".." "$dump" \
+    "stored entry should not preserve dot-dot segments"
+}
+
+test_no_resolve_keeps_two_symlinks_distinct() {
+  # Negative-of-the-headline-case: with NO_RESOLVE, `link1' and
+  # `link2' are two different keys even when they share a target.
+  # Removing via link2 must NOT remove the entry added via link1.
+  local target="$TESTDIR/target/inner"
+  mkdir -p "$target"
+  ln -s "$TESTDIR/target" "$TESTDIR/link1"
+  ln -s "$TESTDIR/target" "$TESTDIR/link2"
+
+  ZSHZ_NO_RESOLVE_SYMLINKS=1 zshz --add "$TESTDIR/link1/inner"
+  ZSHZ_NO_RESOLVE_SYMLINKS=1 zshz -x "$TESTDIR/link2/inner"
+
+  assert_eq "1" "$(zshz_rank_of "$TESTDIR/link1/inner")" \
+    "NO_RESOLVE: -x via link2 should not remove the link1 entry"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/link2/inner")" \
+    "NO_RESOLVE: link2 entry should never have been written"
+
+  # Removing via the same path that added it does work, restoring
+  # the round-trip property even under NO_RESOLVE.
+  ZSHZ_NO_RESOLVE_SYMLINKS=1 zshz -x "$TESTDIR/link1/inner"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/link1/inner")" \
+    "NO_RESOLVE: -x via link1 should remove the link1 entry"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_symlinks.zsh
+++ b/tests/test_symlinks.zsh
@@ -46,3 +46,4 @@ test_symlink_add_no_resolve_does_not_store_target() {
   ZSHZ_NO_RESOLVE_SYMLINKS=1 zshz --add "$link"
   assert_eq "" "$(zshz_rank_of "$target")" "NO_RESOLVE should not silently store the resolved target"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_symlinks.zsh
+++ b/tests/test_symlinks.zsh
@@ -1,0 +1,48 @@
+# Symlink add/remove parity.
+#
+# `--add` and `-x` should treat the same symlink path the same way: whatever
+# `--add foo/link` stored, `-x foo/link` should remove. This must hold both
+# when symlinks are resolved (default) and when ZSHZ_NO_RESOLVE_SYMLINKS=1.
+
+test_symlink_add_remove_parity_default() {
+  local target="$TESTDIR/target" link="$TESTDIR/link"
+  mkdir -p "$target"
+  ln -s "$target" "$link"
+
+  zshz --add "$link"
+  assert_ne "" "$(zshz_dump)" "datafile should have an entry after --add"
+
+  zshz -x "$link"
+  assert_eq "" "$(zshz_dump)" "datafile should be empty after -x on same symlink"
+}
+
+test_symlink_add_remove_parity_no_resolve() {
+  local target="$TESTDIR/target" link="$TESTDIR/link"
+  mkdir -p "$target"
+  ln -s "$target" "$link"
+
+  ZSHZ_NO_RESOLVE_SYMLINKS=1 zshz --add "$link"
+  assert_eq "1" "$(zshz_rank_of "$link")" "with NO_RESOLVE, link path itself should be stored"
+
+  ZSHZ_NO_RESOLVE_SYMLINKS=1 zshz -x "$link"
+  assert_eq "" "$(zshz_rank_of "$link")" "with NO_RESOLVE, -x on link should remove it"
+}
+
+test_symlink_add_default_stores_resolved_target() {
+  local target="$TESTDIR/target" link="$TESTDIR/link"
+  mkdir -p "$target"
+  ln -s "$target" "$link"
+
+  zshz --add "$link"
+  assert_eq "1" "$(zshz_rank_of "$target")" "default mode should store the resolved target"
+  assert_eq "" "$(zshz_rank_of "$link")" "default mode should not store the symlink path"
+}
+
+test_symlink_add_no_resolve_does_not_store_target() {
+  local target="$TESTDIR/target" link="$TESTDIR/link"
+  mkdir -p "$target"
+  ln -s "$target" "$link"
+
+  ZSHZ_NO_RESOLVE_SYMLINKS=1 zshz --add "$link"
+  assert_eq "" "$(zshz_rank_of "$target")" "NO_RESOLVE should not silently store the resolved target"
+}

--- a/tests/test_tempfile_cleanup.zsh
+++ b/tests/test_tempfile_cleanup.zsh
@@ -1,0 +1,94 @@
+# `_zshz_add_or_remove_path' must not leave behind `${datafile}.NNNNN'
+# tempfiles after a write failure or under normal operation.
+#
+# The plugin uses `${datafile}.${RANDOM}' as a per-write tempfile and
+# atomically `mv's it over the datafile. There are several failure
+# paths -- the rewrite can fail at write, at chown, or at mv -- and
+# each must `rm -f' the tempfile before returning.
+#
+# `test_concurrent_mixed.zsh' already pins the no-tempfile-after-
+# concurrent-ops invariant for the mixed-add/-x case. This file
+# pins the single-process failure paths.
+#
+# A few scenarios from the original LIST.md spec are intentionally
+# *not* covered:
+#   - Read-only datafile parent dir: tempfile creation itself fails
+#     (no tempfile to leak), but the mkdir/touch in `[[ -f $datafile ]]
+#     || touch ...' also writes to stderr ahead of `_zshz_add_or_remove_path'.
+#   - SIGKILL mid-write: unavoidable leak; no shell-level handler can
+#     run after SIGKILL. The plugin doesn't trap signals, so SIGTERM
+#     mid-write also leaks. This is a separate "would be nice" item
+#     rather than a contract we currently enforce.
+
+# Glob a directory for `${datafile}.<digits>' tempfiles. Returns 0 if
+# none exist.
+_no_tempfile_in() {
+  local dir=$1 base=${ZSHZ_DATA:t}
+  local -a leftovers
+  leftovers=( "$dir"/${base}.<->(N) )
+  (( ${#leftovers} == 0 )) || \
+    fail "tempfile(s) leftover: ${(j:, :)leftovers}"
+}
+
+test_no_tempfile_after_normal_add() {
+  mkdir -p "$TESTDIR/p"
+  zshz --add "$TESTDIR/p"
+  _no_tempfile_in "$TESTDIR"
+}
+
+test_no_tempfile_after_many_sequential_adds() {
+  # Guards against a bug where each `--add' leaks one tempfile, which
+  # would surface as accumulation rather than a single leftover.
+  local i
+  for ((i=0; i<20; i++)); do
+    mkdir -p "$TESTDIR/p_$i"
+    zshz --add "$TESTDIR/p_$i"
+  done
+  _no_tempfile_in "$TESTDIR"
+}
+
+test_no_tempfile_after_mv_failure() {
+  # Mock `${ZSHZ[MV]}' with `false' so the rename step always fails.
+  # The plugin's failure path (`(( write_ret != 0 )) && rm -f tempfile')
+  # must clean up the tempfile it just wrote.
+  mkdir -p "$TESTDIR/p"
+  zshz_seed "$TESTDIR/seed" 5 60   # pre-existing entry to verify it survives
+  ZSHZ[MV]=false
+  zshz --add "$TESTDIR/p"
+  ZSHZ[MV]=mv   # restore for later tests in the same runner
+
+  _no_tempfile_in "$TESTDIR"
+  # Datafile content should be unchanged because the mv never landed.
+  assert_eq "5" "$(zshz_rank_of "$TESTDIR/seed")" \
+    "pre-existing entry should be unchanged when mv fails"
+  assert_eq "" "$(zshz_rank_of "$TESTDIR/p")" \
+    "new entry should not appear when the rename failed"
+}
+
+test_no_tempfile_after_lock_timeout() {
+  # The lock-timeout path returns before opening the tempfile, so
+  # there's nothing to clean up. This test pins that property -- a
+  # future refactor that opens the tempfile before `flock' would
+  # surface as a leak here.
+  if ! (( ZSHZ[USE_FLOCK] )); then
+    print "skip: zsystem flock unavailable"
+    return 0
+  fi
+
+  mkdir -p "$TESTDIR/p"
+  touch "${ZSHZ_DATA}.lock"
+
+  zsh --no-rcs -c "
+    zmodload zsh/system
+    zsystem flock '${ZSHZ_DATA}.lock'
+    sleep 3
+  " &!
+  local holder=$!
+  sleep 0.2
+
+  ZSHZ_LOCK_TIMEOUT=1 zshz --add "$TESTDIR/p"
+  kill $holder 2>/dev/null
+
+  _no_tempfile_in "$TESTDIR"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_tilde.zsh
+++ b/tests/test_tilde.zsh
@@ -7,7 +7,8 @@ test_tilde_replaces_home_in_list_output() {
   mkdir -p "$HOME/sub"
   zshz --add "$HOME/sub"
   ZSHZ_TILDE=1
-  local out=$(zshz -l)
+  local out
+  out=$(zshz -l)
   assert_contains "~/sub" "$out" "ZSHZ_TILDE=1 should display ~ for HOME prefix in -l"
   assert_not_contains "$HOME/sub" "$out" "raw HOME path should not appear when TILDE is on"
 }
@@ -16,7 +17,8 @@ test_tilde_off_shows_full_home_path() {
   local HOME="$TESTDIR"
   mkdir -p "$HOME/sub"
   zshz --add "$HOME/sub"
-  local out=$(zshz -l)
+  local out
+  out=$(zshz -l)
   assert_contains "$HOME/sub" "$out" "without TILDE, full HOME path should be shown"
 }
 
@@ -25,6 +27,7 @@ test_tilde_in_echo_output() {
   mkdir -p "$HOME/foo"
   zshz --add "$HOME/foo"
   ZSHZ_TILDE=1
-  local out=$(zshz -e foo)
+  local out
+  out=$(zshz -e foo)
   assert_eq "~/foo" "$out" "-e with TILDE should print ~ form"
 }

--- a/tests/test_tilde.zsh
+++ b/tests/test_tilde.zsh
@@ -1,0 +1,30 @@
+# ZSHZ_TILDE: display $HOME as ~ in user-facing output (-l, -e).
+#
+# Each test overrides HOME locally so we don't pollute the real home.
+
+test_tilde_replaces_home_in_list_output() {
+  local HOME="$TESTDIR"
+  mkdir -p "$HOME/sub"
+  zshz --add "$HOME/sub"
+  ZSHZ_TILDE=1
+  local out=$(zshz -l)
+  assert_contains "~/sub" "$out" "ZSHZ_TILDE=1 should display ~ for HOME prefix in -l"
+  assert_not_contains "$HOME/sub" "$out" "raw HOME path should not appear when TILDE is on"
+}
+
+test_tilde_off_shows_full_home_path() {
+  local HOME="$TESTDIR"
+  mkdir -p "$HOME/sub"
+  zshz --add "$HOME/sub"
+  local out=$(zshz -l)
+  assert_contains "$HOME/sub" "$out" "without TILDE, full HOME path should be shown"
+}
+
+test_tilde_in_echo_output() {
+  local HOME="$TESTDIR"
+  mkdir -p "$HOME/foo"
+  zshz --add "$HOME/foo"
+  ZSHZ_TILDE=1
+  local out=$(zshz -e foo)
+  assert_eq "~/foo" "$out" "-e with TILDE should print ~ form"
+}

--- a/tests/test_tilde.zsh
+++ b/tests/test_tilde.zsh
@@ -31,3 +31,4 @@ test_tilde_in_echo_output() {
   out=$(zshz -e foo)
   assert_eq "~/foo" "$out" "-e with TILDE should print ~ form"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_uncommon.zsh
+++ b/tests/test_uncommon.zsh
@@ -22,12 +22,9 @@ test_default_with_single_match_returns_full_path() {
 
 test_default_returns_common_root_when_one_exists() {
   mkdir -p "$TESTDIR/cr/aaa" "$TESTDIR/cr/bbb"
-  local now=$EPOCHSECONDS
-  print -l \
-    "$TESTDIR/cr|1|$((now - 60))" \
-    "$TESTDIR/cr/aaa|100|$((now - 60))" \
-    "$TESTDIR/cr/bbb|50|$((now - 60))" \
-    > "$ZSHZ_DATA"
+  zshz_seed "$TESTDIR/cr" 1 60
+  zshz_seed "$TESTDIR/cr/aaa" 100 60
+  zshz_seed "$TESTDIR/cr/bbb" 50 60
   local out=$(zshz -e cr)
   assert_eq "$TESTDIR/cr" "$out" "default should pick the common-root entry over the highest-rank child"
 }

--- a/tests/test_uncommon.zsh
+++ b/tests/test_uncommon.zsh
@@ -1,0 +1,33 @@
+# ZSHZ_UNCOMMON: shrink the destination path to the shortest level that still
+# preserves the count of the search pattern in the path. Distinct from the
+# default behavior, which prefers the common root of all matches when one
+# exists. (zsh-z.plugin.zsh:849-876, ~591)
+
+test_uncommon_shrinks_to_keep_pattern_count() {
+  # /foo/bar/foo/bar contains "foo" twice; with query "foo", UNCOMMON should
+  # shrink to /foo/bar/foo (the shortest ancestor that still has both "foo"s).
+  mkdir -p "$TESTDIR/foo/bar/foo/bar"
+  zshz --add "$TESTDIR/foo/bar/foo/bar"
+  ZSHZ_UNCOMMON=1
+  local out=$(zshz -e foo)
+  assert_eq "$TESTDIR/foo/bar/foo" "$out" "UNCOMMON should keep both 'foo' occurrences"
+}
+
+test_default_with_single_match_returns_full_path() {
+  mkdir -p "$TESTDIR/foo/bar/foo/bar"
+  zshz --add "$TESTDIR/foo/bar/foo/bar"
+  local out=$(zshz -e foo)
+  assert_eq "$TESTDIR/foo/bar/foo/bar" "$out" "default with single match should return the full path"
+}
+
+test_default_returns_common_root_when_one_exists() {
+  mkdir -p "$TESTDIR/cr/aaa" "$TESTDIR/cr/bbb"
+  local now=$EPOCHSECONDS
+  print -l \
+    "$TESTDIR/cr|1|$((now - 60))" \
+    "$TESTDIR/cr/aaa|100|$((now - 60))" \
+    "$TESTDIR/cr/bbb|50|$((now - 60))" \
+    > "$ZSHZ_DATA"
+  local out=$(zshz -e cr)
+  assert_eq "$TESTDIR/cr" "$out" "default should pick the common-root entry over the highest-rank child"
+}

--- a/tests/test_uncommon.zsh
+++ b/tests/test_uncommon.zsh
@@ -9,14 +9,16 @@ test_uncommon_shrinks_to_keep_pattern_count() {
   mkdir -p "$TESTDIR/foo/bar/foo/bar"
   zshz --add "$TESTDIR/foo/bar/foo/bar"
   ZSHZ_UNCOMMON=1
-  local out=$(zshz -e foo)
+  local out
+  out=$(zshz -e foo)
   assert_eq "$TESTDIR/foo/bar/foo" "$out" "UNCOMMON should keep both 'foo' occurrences"
 }
 
 test_default_with_single_match_returns_full_path() {
   mkdir -p "$TESTDIR/foo/bar/foo/bar"
   zshz --add "$TESTDIR/foo/bar/foo/bar"
-  local out=$(zshz -e foo)
+  local out
+  out=$(zshz -e foo)
   assert_eq "$TESTDIR/foo/bar/foo/bar" "$out" "default with single match should return the full path"
 }
 
@@ -25,6 +27,7 @@ test_default_returns_common_root_when_one_exists() {
   zshz_seed "$TESTDIR/cr" 1 60
   zshz_seed "$TESTDIR/cr/aaa" 100 60
   zshz_seed "$TESTDIR/cr/bbb" 50 60
-  local out=$(zshz -e cr)
+  local out
+  out=$(zshz -e cr)
   assert_eq "$TESTDIR/cr" "$out" "default should pick the common-root entry over the highest-rank child"
 }

--- a/tests/test_uncommon.zsh
+++ b/tests/test_uncommon.zsh
@@ -1,7 +1,6 @@
-# ZSHZ_UNCOMMON: shrink the destination path to the shortest level that still
-# preserves the count of the search pattern in the path. Distinct from the
-# default behavior, which prefers the common root of all matches when one
-# exists. (zsh-z.plugin.zsh:849-876, ~591)
+# ZSHZ_UNCOMMON: shrink the chosen destination to the shortest level that still
+# preserves how many times the search pattern appears in the path. Distinct
+# from the default behavior, which prefers a shared common root when one exists.
 
 test_uncommon_shrinks_to_keep_pattern_count() {
   # /foo/bar/foo/bar contains "foo" twice; with query "foo", UNCOMMON should

--- a/tests/test_uncommon.zsh
+++ b/tests/test_uncommon.zsh
@@ -30,3 +30,4 @@ test_default_returns_common_root_when_one_exists() {
   out=$(zshz -e cr)
   assert_eq "$TESTDIR/cr" "$out" "default should pick the common-root entry over the highest-rank child"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_unicode.zsh
+++ b/tests/test_unicode.zsh
@@ -1,0 +1,76 @@
+# Round-trip behaviour for paths containing non-ASCII characters.
+#
+# Three scripts represent distinct UTF-8 categories: Latin-extended
+# (single-codepoint accented chars), CJK (multi-byte ideographs), and
+# Cyrillic (a separate alphabet exercising any locale-dependent paths).
+# Each test creates the directory on disk so the missing-directory
+# prune doesn't drop the entry, then verifies add, search by ASCII or
+# native substring, listing, and remove via `-x'.
+
+test_path_with_latin_extended_round_trip() {
+  local p="$TESTDIR/café/résumé"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land Latin-extended path"
+
+  local out
+  out=$(zshz -e café)
+  assert_eq "$p" "$out" "search by native substring should find Latin-extended path"
+
+  local list
+  list=$(zshz -l)
+  assert_contains "café" "$list" "list should include Latin-extended path"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear Latin-extended path"
+}
+
+test_path_with_cjk_round_trip() {
+  local p="$TESTDIR/日本語/プロジェクト"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land CJK path"
+
+  local out
+  out=$(zshz -e 日本語)
+  assert_eq "$p" "$out" "search by CJK substring should find CJK path"
+
+  local list
+  list=$(zshz -l)
+  assert_contains "日本語" "$list" "list should include CJK path"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear CJK path"
+}
+
+test_path_with_cyrillic_round_trip() {
+  local p="$TESTDIR/привет/мир"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add should land Cyrillic path"
+
+  local out
+  out=$(zshz -e привет)
+  assert_eq "$p" "$out" "search by Cyrillic substring should find Cyrillic path"
+
+  local list
+  list=$(zshz -l)
+  assert_contains "привет" "$list" "list should include Cyrillic path"
+
+  zshz -x "$p"
+  assert_eq "" "$(zshz_rank_of "$p")" "remove should clear Cyrillic path"
+}
+
+test_ascii_substring_finds_path_with_unicode() {
+  # Mixed ASCII / non-ASCII in the same path component, searched by
+  # the ASCII portion. Confirms substring matching crosses byte
+  # boundaries cleanly when the search query stays in ASCII.
+  local p="$TESTDIR/proj-café-2026/notes"
+  mkdir -p "$p"
+  zshz --add "$p"
+
+  local out
+  out=$(zshz -e proj)
+  assert_eq "$p" "$out" "ASCII query should find a path that contains non-ASCII chars elsewhere"
+}
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_unicode.zsh
+++ b/tests/test_unicode.zsh
@@ -73,4 +73,97 @@ test_ascii_substring_finds_path_with_unicode() {
   out=$(zshz -e proj)
   assert_eq "$p" "$out" "ASCII query should find a path that contains non-ASCII chars elsewhere"
 }
+
+test_issue_48_cjk_echo_returns_byte_exact_path() {
+  # Direct regression for https://github.com/agkozak/zsh-z/issues/48
+  # — `zshz -e TW' against a path containing CJK characters used to
+  # return a corrupted string (e.g. "TW4791主僣" instead of the real
+  # "TW4791主包内容") because Zsh's `print -v REPLY <arg>' mangled
+  # multibyte strings until late 2020. `_zshz_printv' works around
+  # that by using `print -v REPLY -f %s <arg>'; if anyone simplifies
+  # the helper back to the plain form, this test fails.
+  local p="$TESTDIR/TW4791主包内容"
+  mkdir -p "$p"
+  zshz --add "$p"
+
+  local out
+  out=$(zshz -e TW)
+  assert_eq "$p" "$out" \
+    "z -e must return the byte-exact CJK path; issue #48 corrupted the trailing CJK chars"
+}
+
+test_common_root_line_preserves_multibyte_prefix() {
+  # `_zshz_find_common_root' funnels the shared prefix through
+  # `_zshz_printv -- $short' (a separate callsite from the `-e' path
+  # exercised above). The "common: PATH" line in `-l' output is what
+  # surfaces it; assert the prefix bytes come through verbatim.
+  #
+  # The plugin's common-root algorithm only emits the line when the
+  # common prefix is itself one of the matched paths, so the parent
+  # `プロジェクト' directory needs to be in the database too.
+  local root="$TESTDIR/プロジェクト"
+  local a="$root/alpha" b="$root/beta" c="$root/gamma"
+  mkdir -p "$a" "$b" "$c"
+  zshz --add "$root"
+  zshz --add "$a"
+  zshz --add "$b"
+  zshz --add "$c"
+
+  local list
+  list=$(zshz -l プロジェクト)
+  assert_contains "common:" "$list" \
+    "list should emit a 'common:' line when matches share a prefix"
+  assert_contains "$root" "$list" \
+    "the multibyte common prefix must appear byte-exact in the list output"
+}
+
+test_cjk_path_with_escape_special_chars_round_trips() {
+  # Combination of #48's concern (multibyte) and the
+  # associative-array escape chain in `_zshz_find_matches'
+  # ([:751-768]): a path that hits BOTH must survive add + search
+  # without corruption.
+  local p="$TESTDIR/project(主包)/notes"
+  mkdir -p "$p"
+  zshz --add "$p"
+  assert_eq "1" "$(zshz_rank_of "$p")" "add must land path with CJK + parens"
+
+  local out
+  out=$(zshz -e 主包)
+  assert_eq "$p" "$out" \
+    "search by CJK substring must return byte-exact path containing escape-targeted chars"
+}
+
+test_cjk_substring_matches_at_start_middle_and_end() {
+  # Substring matching that crosses byte boundaries: the multibyte
+  # component sits at the start, middle, and end of three different
+  # paths. Verifies the `*$fnd*' glob doesn't accidentally split on
+  # byte rather than character boundaries.
+  local at_start="$TESTDIR/日本/src"
+  local at_middle="$TESTDIR/prj/日本/build"
+  local at_end="$TESTDIR/notes/2026/日本"
+  mkdir -p "$at_start" "$at_middle" "$at_end"
+  zshz --add "$at_start"
+  zshz --add "$at_middle"
+  zshz --add "$at_end"
+
+  local list
+  list=$(zshz -l 日本)
+  assert_contains "$at_start"  "$list" "CJK substring at path start should match"
+  assert_contains "$at_middle" "$list" "CJK substring mid-path should match"
+  assert_contains "$at_end"    "$list" "CJK substring at path end should match"
+}
+
+test_case_insensitive_mode_does_not_corrupt_cjk() {
+  # `ZSHZ_CASE=ignore' lowercases both sides via `:l'. For chars
+  # without a case (most CJK), `:l' is a no-op; the test pins that
+  # this no-op stays a no-op rather than mangling the bytes.
+  local p="$TESTDIR/日本語/notes"
+  mkdir -p "$p"
+  ZSHZ_CASE=ignore zshz --add "$p"
+
+  local out
+  out=$(ZSHZ_CASE=ignore zshz -e 日本語)
+  assert_eq "$p" "$out" \
+    "ZSHZ_CASE=ignore must not corrupt CJK chars during case folding"
+}
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_unload.zsh
+++ b/tests/test_unload.zsh
@@ -9,7 +9,8 @@
 # Each test runs in a fresh `zsh --no-rcs -c` subshell.
 
 test_unload_removes_zshz_function() {
-  local out=$(zshz_in_fresh_shell '
+  local out
+  out=$(zshz_in_fresh_shell '
     zsh-z_plugin_unload
     print -- ${+functions[zshz]}
   ')
@@ -17,7 +18,8 @@ test_unload_removes_zshz_function() {
 }
 
 test_unload_unsets_ZSHZ_global() {
-  local out=$(zshz_in_fresh_shell '
+  local out
+  out=$(zshz_in_fresh_shell '
     zsh-z_plugin_unload
     print -- ${+ZSHZ}
   ')
@@ -25,7 +27,8 @@ test_unload_unsets_ZSHZ_global() {
 }
 
 test_unload_removes_widget() {
-  local out=$(zshz_in_fresh_shell '
+  local out
+  out=$(zshz_in_fresh_shell '
     zsh-z_plugin_unload
     print -- ${+widgets[_zshz_zle_completion_widget]}
   ')
@@ -33,7 +36,8 @@ test_unload_removes_widget() {
 }
 
 test_unload_restores_prior_tab_binding() {
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     zsh-z_plugin_unload
     bindkey -M main '^I'
   ")
@@ -45,7 +49,8 @@ test_unload_leaves_user_rebound_tab_alone() {
   # If the user rebinds Tab themselves after sourcing, unload must NOT silently
   # undo that rebind. Regression for commit e55ae41 ("unload: only restore Tab
   # binding when appropriate").
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     bindkey -M main '^I' menu-complete
     zsh-z_plugin_unload
     bindkey -M main '^I'
@@ -54,7 +59,8 @@ test_unload_leaves_user_rebound_tab_alone() {
 }
 
 test_unload_removes_hooks() {
-  local out=$(zshz_in_fresh_shell '
+  local out
+  out=$(zshz_in_fresh_shell '
     zsh-z_plugin_unload
     print precmd=${precmd_functions[(r)_zshz_precmd]:-none}
     print chpwd=${chpwd_functions[(r)_zshz_chpwd]:-none}
@@ -64,14 +70,16 @@ test_unload_removes_hooks() {
 }
 
 test_unload_then_reload_restores_function_and_widget() {
-  local out=$(zshz_in_fresh_shell "
+  local out
+  local -a lines
+  out=$(zshz_in_fresh_shell "
     zsh-z_plugin_unload
     source '$PLUGIN_DIR/zsh-z.plugin.zsh'
     print -- \${+functions[zshz]}
     print -- \${+widgets[_zshz_zle_completion_widget]}
     bindkey -M main '^I'
   ")
-  local -a lines=( ${(f)out} )
+  lines=( ${(f)out} )
   assert_eq "1" "$lines[1]" "zshz function should exist after reload"
   assert_eq "1" "$lines[2]" "widget should exist after reload"
   assert_contains "_zshz_zle_completion_widget" "$lines[3]" "Tab should be bound to widget after reload"
@@ -81,7 +89,8 @@ test_reload_after_unload_captures_current_tab_binding() {
   # After unload restored the prior binding, re-sourcing should treat the
   # *current* Tab binding as "the binding to chain to" -- not stale state from
   # before the unload.
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     zsh-z_plugin_unload
     bindkey -M main '^I' menu-complete
     source '$PLUGIN_DIR/zsh-z.plugin.zsh'

--- a/tests/test_unload.zsh
+++ b/tests/test_unload.zsh
@@ -1,0 +1,115 @@
+# Plugin unload / reload contract.
+#
+# Per the Zsh Plugin Standard
+# (https://github.com/agkozak/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc#unload-fun),
+# `zsh-z_plugin_unload` should fully remove the plugin: drop its functions and
+# widget, restore the prior Tab binding, remove its precmd/chpwd hooks, and
+# unset the ZSHZ global. Re-sourcing afterward should bring everything back.
+#
+# Each test runs in a fresh `zsh --no-rcs -c` subshell.
+
+test_unload_removes_zshz_function() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zsh-z_plugin_unload
+    print -- \${+functions[zshz]}
+  ")
+  assert_eq "0" "$out" "zshz function should be gone after unload"
+}
+
+test_unload_unsets_ZSHZ_global() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zsh-z_plugin_unload
+    print -- \${+ZSHZ}
+  ")
+  assert_eq "0" "$out" "ZSHZ should be unset after unload"
+}
+
+test_unload_removes_widget() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zsh-z_plugin_unload
+    print -- \${+widgets[_zshz_zle_completion_widget]}
+  ")
+  assert_eq "0" "$out" "widget should be deleted after unload"
+}
+
+test_unload_restores_prior_tab_binding() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zsh-z_plugin_unload
+    bindkey -M main '^I'
+  ")
+  assert_contains "expand-or-complete" "$out" "Tab should return to its prior binding"
+  assert_not_contains "_zshz_zle_completion_widget" "$out" "widget should not still be on Tab"
+}
+
+test_unload_leaves_user_rebound_tab_alone() {
+  # If the user rebinds Tab themselves after sourcing, unload must NOT silently
+  # undo that rebind. Regression for commit e55ae41 ("unload: only restore Tab
+  # binding when appropriate").
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    bindkey -M main '^I' menu-complete
+    zsh-z_plugin_unload
+    bindkey -M main '^I'
+  ")
+  assert_contains "menu-complete" "$out" "user's later rebind should survive unload"
+}
+
+test_unload_removes_hooks() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zsh-z_plugin_unload
+    print precmd=\${precmd_functions[(r)_zshz_precmd]:-none}
+    print chpwd=\${chpwd_functions[(r)_zshz_chpwd]:-none}
+  ")
+  assert_contains "precmd=none" "$out" "_zshz_precmd hook should be gone"
+  assert_contains "chpwd=none" "$out" "_zshz_chpwd hook should be gone"
+}
+
+test_unload_then_reload_restores_function_and_widget() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zsh-z_plugin_unload
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    print -- \${+functions[zshz]}
+    print -- \${+widgets[_zshz_zle_completion_widget]}
+    bindkey -M main '^I'
+  ")
+  local -a lines=( ${(f)out} )
+  assert_eq "1" "$lines[1]" "zshz function should exist after reload"
+  assert_eq "1" "$lines[2]" "widget should exist after reload"
+  assert_contains "_zshz_zle_completion_widget" "$lines[3]" "Tab should be bound to widget after reload"
+}
+
+test_reload_after_unload_captures_current_tab_binding() {
+  # After unload restored the prior binding, re-sourcing should treat the
+  # *current* Tab binding as "the binding to chain to" -- not stale state from
+  # before the unload.
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zsh-z_plugin_unload
+    bindkey -M main '^I' menu-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    print -- \$ZSHZ[TAB_BINDING]
+  ")
+  assert_eq "menu-complete" "$out" "reload should capture the binding present at reload time"
+}

--- a/tests/test_unload.zsh
+++ b/tests/test_unload.zsh
@@ -98,3 +98,4 @@ test_reload_after_unload_captures_current_tab_binding() {
   ")
   assert_eq "menu-complete" "$out" "reload should capture the binding present at reload time"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_unload.zsh
+++ b/tests/test_unload.zsh
@@ -9,43 +9,31 @@
 # Each test runs in a fresh `zsh --no-rcs -c` subshell.
 
 test_unload_removes_zshz_function() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell '
     zsh-z_plugin_unload
-    print -- \${+functions[zshz]}
-  ")
+    print -- ${+functions[zshz]}
+  ')
   assert_eq "0" "$out" "zshz function should be gone after unload"
 }
 
 test_unload_unsets_ZSHZ_global() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell '
     zsh-z_plugin_unload
-    print -- \${+ZSHZ}
-  ")
+    print -- ${+ZSHZ}
+  ')
   assert_eq "0" "$out" "ZSHZ should be unset after unload"
 }
 
 test_unload_removes_widget() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell '
     zsh-z_plugin_unload
-    print -- \${+widgets[_zshz_zle_completion_widget]}
-  ")
+    print -- ${+widgets[_zshz_zle_completion_widget]}
+  ')
   assert_eq "0" "$out" "widget should be deleted after unload"
 }
 
 test_unload_restores_prior_tab_binding() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     zsh-z_plugin_unload
     bindkey -M main '^I'
   ")
@@ -57,10 +45,7 @@ test_unload_leaves_user_rebound_tab_alone() {
   # If the user rebinds Tab themselves after sourcing, unload must NOT silently
   # undo that rebind. Regression for commit e55ae41 ("unload: only restore Tab
   # binding when appropriate").
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     bindkey -M main '^I' menu-complete
     zsh-z_plugin_unload
     bindkey -M main '^I'
@@ -69,23 +54,17 @@ test_unload_leaves_user_rebound_tab_alone() {
 }
 
 test_unload_removes_hooks() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell '
     zsh-z_plugin_unload
-    print precmd=\${precmd_functions[(r)_zshz_precmd]:-none}
-    print chpwd=\${chpwd_functions[(r)_zshz_chpwd]:-none}
-  ")
+    print precmd=${precmd_functions[(r)_zshz_precmd]:-none}
+    print chpwd=${chpwd_functions[(r)_zshz_chpwd]:-none}
+  ')
   assert_contains "precmd=none" "$out" "_zshz_precmd hook should be gone"
   assert_contains "chpwd=none" "$out" "_zshz_chpwd hook should be gone"
 }
 
 test_unload_then_reload_restores_function_and_widget() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     zsh-z_plugin_unload
     source '$PLUGIN_DIR/zsh-z.plugin.zsh'
     print -- \${+functions[zshz]}
@@ -102,10 +81,7 @@ test_reload_after_unload_captures_current_tab_binding() {
   # After unload restored the prior binding, re-sourcing should treat the
   # *current* Tab binding as "the binding to chain to" -- not stale state from
   # before the unload.
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     zsh-z_plugin_unload
     bindkey -M main '^I' menu-complete
     source '$PLUGIN_DIR/zsh-z.plugin.zsh'

--- a/tests/test_widget.zsh
+++ b/tests/test_widget.zsh
@@ -1,0 +1,88 @@
+# ZLE completion widget transformation logic.
+#
+# `_zshz_zle_completion_widget` rewrites `z us lo bi` into `z us*lo*bi` before
+# delegating to the original Tab binding (zsh-z.plugin.zsh:996-1031). We
+# can't drive a real ZLE session non-interactively, so we stub `zle` to a
+# no-op function and inspect LBUFFER after the call.
+
+test_widget_joins_multiple_search_terms_with_asterisk() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zle() { return 0 }
+    LBUFFER='z us lo bi'
+    _zshz_zle_completion_widget
+    print -- \$LBUFFER
+  ")
+  assert_eq "z us*lo*bi" "$out" "multiple terms should be joined with *"
+}
+
+test_widget_preserves_flags_before_search_terms() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zle() { return 0 }
+    LBUFFER='z -e foo bar'
+    _zshz_zle_completion_widget
+    print -- \$LBUFFER
+  ")
+  assert_eq "z -e foo*bar" "$out" "flags should remain separate from joined search terms"
+}
+
+test_widget_passes_through_single_term() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zle() { return 0 }
+    LBUFFER='z foo'
+    _zshz_zle_completion_widget
+    print -- \$LBUFFER
+  ")
+  assert_eq "z foo" "$out" "single term should not be transformed"
+}
+
+test_widget_does_not_retrigger_on_completed_absolute_path() {
+  # When LBUFFER ends with a space after an absolute path (the result of a
+  # successful prior completion), the widget should bail so a second Tab
+  # doesn't re-trigger and produce a duplicate.
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zle() { return 0 }
+    LBUFFER='z /usr/local/bin '
+    _zshz_zle_completion_widget
+    print -- \$LBUFFER
+  ")
+  assert_eq "z /usr/local/bin " "$out" "completed absolute path should pass through unchanged"
+}
+
+test_widget_recognizes_long_flags() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zle() { return 0 }
+    LBUFFER='z --add foo bar'
+    _zshz_zle_completion_widget
+    print -- \$LBUFFER
+  ")
+  assert_eq "z --add foo*bar" "$out" "long flags should be classified as flags, not joined into search terms"
+}
+
+test_widget_uses_custom_ZSHZ_CMD() {
+  local out
+  out=$(zsh --no-rcs -c "
+    bindkey -M main '^I' expand-or-complete
+    ZSHZ_CMD=zoo
+    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+    zle() { return 0 }
+    LBUFFER='zoo us lo'
+    _zshz_zle_completion_widget
+    print -- \$LBUFFER
+  ")
+  assert_eq "zoo us*lo" "$out" "widget should respect a custom ZSHZ_CMD"
+}

--- a/tests/test_widget.zsh
+++ b/tests/test_widget.zsh
@@ -80,7 +80,7 @@ test_widget_uses_custom_ZSHZ_CMD() {
 test_widget_passes_through_single_path_after_long_flag() {
   # `z --add /tmp` <Tab> with one path arg must leave LBUFFER unchanged so
   # filesystem completion can run on /tmp. If --add were ever dropped from the
-  # widget's flag pattern, this would collapse to 'z --add*/tmp'.
+  # widget's option pattern, this would collapse to 'z --add*/tmp'.
   local out
   out=$(zshz_in_fresh_shell "
     zle() { return 0 }
@@ -89,5 +89,21 @@ test_widget_passes_through_single_path_after_long_flag() {
     print -- \$LBUFFER
   ")
   assert_eq "z --add /tmp" "$out" "single path arg after --add must pass through unchanged"
+}
+
+test_widget_double_dash_terminates_option_parsing() {
+  # `--' is the POSIX option terminator: tokens after it are positional, even
+  # if they happen to look like options. Without this, `z -- --add foo bar'
+  # would be classified as option_parts=(-- --add) / search_parts=(foo bar)
+  # and rewritten to 'z -- --add foo*bar' instead of joining all positionals.
+  local out
+  out=$(zshz_in_fresh_shell "
+    zle() { return 0 }
+    LBUFFER='z -- --add foo bar'
+    _zshz_zle_completion_widget
+    print -- \$LBUFFER
+  ")
+  assert_eq "z -- --add*foo*bar" "$out" \
+    "tokens after -- must be treated as positional and joined with *"
 }
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_widget.zsh
+++ b/tests/test_widget.zsh
@@ -1,9 +1,9 @@
 # ZLE completion widget transformation logic.
 #
-# `_zshz_zle_completion_widget` rewrites `z us lo bi` into `z us*lo*bi` before
-# delegating to the original Tab binding (zsh-z.plugin.zsh:996-1031). We
-# can't drive a real ZLE session non-interactively, so we stub `zle` to a
-# no-op function and inspect LBUFFER after the call.
+# `_zshz_zle_completion_widget` collapses multiple search terms after the
+# command into one `*`-joined token before delegating to the saved Tab binding.
+# We can't drive a real ZLE session non-interactively, so we stub `zle` to a
+# no-op function and inspect `LBUFFER` after the call.
 
 test_widget_joins_multiple_search_terms_with_asterisk() {
   local out

--- a/tests/test_widget.zsh
+++ b/tests/test_widget.zsh
@@ -6,7 +6,8 @@
 # no-op function and inspect LBUFFER after the call.
 
 test_widget_joins_multiple_search_terms_with_asterisk() {
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z us lo bi'
     _zshz_zle_completion_widget
@@ -16,7 +17,8 @@ test_widget_joins_multiple_search_terms_with_asterisk() {
 }
 
 test_widget_preserves_flags_before_search_terms() {
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z -e foo bar'
     _zshz_zle_completion_widget
@@ -26,7 +28,8 @@ test_widget_preserves_flags_before_search_terms() {
 }
 
 test_widget_passes_through_single_term() {
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z foo'
     _zshz_zle_completion_widget
@@ -39,7 +42,8 @@ test_widget_does_not_retrigger_on_completed_absolute_path() {
   # When LBUFFER ends with a space after an absolute path (the result of a
   # successful prior completion), the widget should bail so a second Tab
   # doesn't re-trigger and produce a duplicate.
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z /usr/local/bin '
     _zshz_zle_completion_widget
@@ -49,7 +53,8 @@ test_widget_does_not_retrigger_on_completed_absolute_path() {
 }
 
 test_widget_recognizes_long_flags() {
-  local out=$(zshz_in_fresh_shell "
+  local out
+  out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z --add foo bar'
     _zshz_zle_completion_widget

--- a/tests/test_widget.zsh
+++ b/tests/test_widget.zsh
@@ -6,10 +6,7 @@
 # no-op function and inspect LBUFFER after the call.
 
 test_widget_joins_multiple_search_terms_with_asterisk() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z us lo bi'
     _zshz_zle_completion_widget
@@ -19,10 +16,7 @@ test_widget_joins_multiple_search_terms_with_asterisk() {
 }
 
 test_widget_preserves_flags_before_search_terms() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z -e foo bar'
     _zshz_zle_completion_widget
@@ -32,10 +26,7 @@ test_widget_preserves_flags_before_search_terms() {
 }
 
 test_widget_passes_through_single_term() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z foo'
     _zshz_zle_completion_widget
@@ -48,10 +39,7 @@ test_widget_does_not_retrigger_on_completed_absolute_path() {
   # When LBUFFER ends with a space after an absolute path (the result of a
   # successful prior completion), the widget should bail so a second Tab
   # doesn't re-trigger and produce a duplicate.
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z /usr/local/bin '
     _zshz_zle_completion_widget
@@ -61,10 +49,7 @@ test_widget_does_not_retrigger_on_completed_absolute_path() {
 }
 
 test_widget_recognizes_long_flags() {
-  local out
-  out=$(zsh --no-rcs -c "
-    bindkey -M main '^I' expand-or-complete
-    source '$PLUGIN_DIR/zsh-z.plugin.zsh'
+  local out=$(zshz_in_fresh_shell "
     zle() { return 0 }
     LBUFFER='z --add foo bar'
     _zshz_zle_completion_widget

--- a/tests/test_widget.zsh
+++ b/tests/test_widget.zsh
@@ -76,3 +76,4 @@ test_widget_uses_custom_ZSHZ_CMD() {
   ")
   assert_eq "zoo us*lo" "$out" "widget should respect a custom ZSHZ_CMD"
 }
+# vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/tests/test_widget.zsh
+++ b/tests/test_widget.zsh
@@ -76,4 +76,18 @@ test_widget_uses_custom_ZSHZ_CMD() {
   ")
   assert_eq "zoo us*lo" "$out" "widget should respect a custom ZSHZ_CMD"
 }
+
+test_widget_passes_through_single_path_after_long_flag() {
+  # `z --add /tmp` <Tab> with one path arg must leave LBUFFER unchanged so
+  # filesystem completion can run on /tmp. If --add were ever dropped from the
+  # widget's flag pattern, this would collapse to 'z --add*/tmp'.
+  local out
+  out=$(zshz_in_fresh_shell "
+    zle() { return 0 }
+    LBUFFER='z --add /tmp'
+    _zshz_zle_completion_widget
+    print -- \$LBUFFER
+  ")
+  assert_eq "z --add /tmp" "$out" "single path arg after --add must pass through unchanged"
+}
 # vim: fdm=indent:ts=2:et:sts=2:sw=2:

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -827,6 +827,10 @@ zshz() {
   # If $ZSHZ_ECHO == 1, display paths as you jump to them.
   # If it is also the case that $ZSHZ_TILDE == 1, display
   # the home directory as a tilde.
+  #
+  # Globals:
+  #   ZSHZ_ECHO
+  #   ZSHZ_TILDE
   #########################################################
   _zshz_echo() {
     if (( ZSHZ_ECHO )); then
@@ -860,7 +864,8 @@ zshz() {
 
   # New experimental "uncommon" behavior
   #
-  # If the best choice at this point is something like /foo/bar/foo/bar, and the  # search pattern is `bar', go to /foo/bar/foo/bar; but if the search pattern
+  # If the best choice at this point is something like /foo/bar/foo/bar, and the
+  # # search pattern is `bar', go to /foo/bar/foo/bar; but if the search pattern
   # is `foo', go to /foo/bar/foo
   if (( ZSHZ_UNCOMMON )) && [[ -n $cd ]]; then
     if [[ -n $cd ]]; then

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -1022,7 +1022,7 @@ _zshz_zle_completion_widget() {
 
     parts=( ${(z)after} )
     for p in $parts; do
-      if (( ! past_flags )) && [[ $p == (-[cehlrRtx]##|--add|--complete|--help) ]]; then
+      if (( ! past_flags )) && [[ $p == (--|-[cehlrRtx]##|--add|--complete|--help) ]]; then
         flag_parts+=( $p )
       else
         past_flags=1

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -116,24 +116,19 @@ With no ARGUMENT, list the directory history in ascending rank.
 typeset -gA ZSHZ
 
 # Fallback utilities in case Zsh lacks zsh/files (as is the case with MobaXterm)
-ZSHZ[CHMOD]='chmod'
 ZSHZ[CHOWN]='chown'
 ZSHZ[MV]='mv'
 ZSHZ[RM]='rm'
 # Try to load zsh/files utilities
-if [[ ${builtins[zf_chmod]-} != 'defined' ||
-      ${builtins[zf_chown]-} != 'defined' ||
+if [[ ${builtins[zf_chown]-} != 'defined' ||
       ${builtins[zf_mv]-}    != 'defined' ||
       ${builtins[zf_rm]-}    != 'defined' ]]; then
-  zmodload -F zsh/files b:zf_chmod b:zf_chown b:zf_mv b:zf_rm &> /dev/null
+  zmodload -F zsh/files b:zf_chown b:zf_mv b:zf_rm &> /dev/null
 fi
 # Use zsh/files, if it is available
-[[ ${builtins[zf_chmod]-} == 'defined' ]] && ZSHZ[CHMOD]='zf_chmod'
 [[ ${builtins[zf_chown]-} == 'defined' ]] && ZSHZ[CHOWN]='zf_chown'
 [[ ${builtins[zf_mv]-} == 'defined' ]] && ZSHZ[MV]='zf_mv'
 [[ ${builtins[zf_rm]-} == 'defined' ]] && ZSHZ[RM]='zf_rm'
-# MSYS2's chmod is a no-op on Windows filesystems; skip it there
-[[ $OSTYPE == msys ]] && ZSHZ[CHMOD]=':'
 
 # Load zsh/system, if necessary
 [[ ${modules[zsh/system]-} == 'loaded' ]] || zmodload zsh/system &> /dev/null
@@ -196,9 +191,15 @@ zshz() {
   fi
 
   # Make sure that the datafile exists before attempting to read it or lock it
-  # for writing
+  # for writing. The file is born at 0600 via a temporary umask change rather
+  # than a follow-up chmod: zf_chmod doesn't exist before zsh 5.x, so a chmod
+  # here would fork/exec /usr/bin/chmod and noticeably slow precmd on 4.3.11.
   [[ -f $datafile ]] || {
-    mkdir -p "${datafile:h}" && touch "$datafile" && ${ZSHZ[CHMOD]} 600 "$datafile"
+    mkdir -p "${datafile:h}"
+    local _saved_umask=$(umask)
+    umask 077
+    touch "$datafile"
+    umask "$_saved_umask"
     # When $ZSHZ_OWNER is set (e.g. under `sudo -s'), hand the freshly created
     # file off to that user immediately, so a query-only invocation can't leave
     # behind a root-owned .z that the normal-user shell can't read.
@@ -246,6 +247,14 @@ zshz() {
     local tempfile="${datafile}.${RANDOM}" lockfile="${datafile}.lock"
     integer lockfd=0
 
+    # Birth the tempfile at 0600 via umask rather than chmodding after the
+    # fact -- on zsh 4.3.11 there is no zf_chmod, and forking /usr/bin/chmod
+    # inside the locked section noticeably increases the share of precmd
+    # writes that miss the flock window. The always-block restores the
+    # caller's umask even on early return.
+    local saved_umask=$(umask)
+    umask 077
+
     {
       # Using zsystem flock
       if (( ZSHZ[USE_FLOCK] )); then
@@ -275,7 +284,6 @@ zshz() {
       case $action in
         --add)
           exec {tmpfd}>|"$tempfile"  # Open up tempfile for writing
-          ${ZSHZ[CHMOD]} 600 "$tempfile"
           _zshz_update_datafile $tmpfd "$*"
           local ret=$?
           ;;
@@ -308,7 +316,6 @@ zshz() {
             return 1  # The $PWD isn't in the datafile
           fi
           exec {tmpfd}>|"$tempfile"  # Open up tempfile for writing
-          ${ZSHZ[CHMOD]} 600 "$tempfile"
           print -u $tmpfd -l -- $lines
           local ret=$?
           ;;
@@ -376,6 +383,7 @@ zshz() {
         fi
       fi
     } always {
+      umask "$saved_umask"
       # zsystem flock -f opens a real fd; explicitly unlock it so repeated
       # foreground precmd writes don't leak lock descriptors and stall peers.
       (( lockfd != 0 )) && zsystem flock -u $lockfd 2> /dev/null

--- a/zsh-z.plugin.zsh
+++ b/zsh-z.plugin.zsh
@@ -688,6 +688,7 @@ zshz() {
     local -i is_lowercase_query=0
     [[ ${1:l} == $1 ]] && is_lowercase_query=1
     local -i trail=${ZSHZ_TRAILING_SLASH:-0}
+    local now=$EPOCHSECONDS
 
     for line in $lines; do
       path_field=${line%%\|*}
@@ -714,10 +715,10 @@ zshz() {
 
       case $method in
         rank) rank=$rank_field ;;
-        time) (( rank = time_field - EPOCHSECONDS )) ;;
+        time) (( rank = time_field - now )) ;;
         *)
           # Frecency routine
-          (( dx = EPOCHSECONDS - time_field ))
+          (( dx = now - time_field ))
           rank=$(( 10000 * rank_field * (3.75/( (0.0001 * dx + 1) + 0.25)) ))
           ;;
       esac
@@ -911,7 +912,7 @@ zshz() {
   # of `_zshz_output' but operates straight on $lines.
   if [[ $output_format == 'list' && -z $fnd ]]; then
     local line path_field rank_field time_field rank dx path_to_display dir
-    local common
+    local common now=$EPOCHSECONDS
     local -a output paths
     local -i keep
 
@@ -933,9 +934,9 @@ zshz() {
       time_field=${line##*\|}
       case $method in
         rank) rank=$rank_field ;;
-        time) (( rank = time_field - EPOCHSECONDS )) ;;
+        time) (( rank = time_field - now )) ;;
         *)
-          (( dx = EPOCHSECONDS - time_field ))
+          (( dx = now - time_field ))
           rank=$(( 10000 * rank_field * (3.75/( (0.0001 * dx + 1) + 0.25)) ))
           ;;
       esac


### PR DESCRIPTION
- **Regression tests and CI**
- **More tests**
- **More tests**
- **tests: Factor out repeated seed and subshell boilerplate**
- **Moving towards Zsh 4.3.11 compatibility for test suite**
- **Tests don't hang in Zsh 4.3.11 anymore**
- **Improved comments**
- **Comments**
- **Modelines**
- **Completion widget flag pattern should include --**
- **Test helpers: use literal string comparison in assert_eq/assert_ne**
- **tests: regression coverage for --complete side effects**
- **tests: cover ZSHZ_OWNER lockfile chown**
- **tests: cover -- as POSIX option terminator in widget**
- **Allow specifying individual tests to run**
- **Attempt to test concurrency when Zsh is v4.3.11**
- **Avoid warning from xargs**
- **Test changed to reflect improved exit behavior**
- **Tests reflecting changes to lockfile technique**
- **Another concurrency test**
- **tests: wait for backgrounded precmd add before asserting**
- **tests: assert &! precmd emits no "Done" line**
- **tests: assert _zshz_precmd doesn't leak lockfile fds**
- **tests: extend datafile-robustness coverage**
- **tests: cover read-only ops on missing/empty datafiles**
- **tests: add a scale-smoke suite (skipped unless ZSHZ_HEAVY_TESTS is set)**
- **tests: coverage for paths with special characters**
- **tests: include $-paths in test suite**
- **tests: non-ASCII paths**
- **tests: pin _zshz_find_common_root behaviour across input orderings**
- **tests: pin manual --add behavior**
- **tests: source plugin under sh/bash/ksh emulation**
- **tests: source with NO_UNSET, WARN_CREATE_GLOBAL, NO_NOMATCH**
- **tests: config errors should return, not exit**
- **tests: assert ZSHZ_LOCK_TIMEOUT bails out and leaves the datafile alone**
- **tests: assert datafile stays well-formed under concurrent --add and -x**
- **tests: Make sure preexisting entries survive concurrent updates**
- **tests: Make sure no tempfiles are left over**
- **tests: symlink edge cases**
- **tests: ZSHZ_KEEP_DIRS edge cases**
- **tests: ZSHZ_MAX_SCORE should shrink rank, not remove entries**
- **tests: compatibility with Solaris**
- **tests: give the interactive precmd test more headroom on slow hosts**
- **tests: continuing to diagnose Solaris**
- **tests: Now compatible with Zsh 5.9 & 4.3.11 again**
- **tests: Problems with zpty on Cygwin**
- **tests: accept that MobaXterm's Cygwin has no flock**
- **tests: cover .z permission hardening (#92)**
- **tests: account for umask**
- **tests: cover umask containment under abnormal exit**
- **tests: skip umask-touch-fail test on the chmod path**
- **tests: MSYS2 ignores chmod**
- **tests: skip the interactive pty test on non-Linux platforms**
- **tests: portable mktemp template for Solaris/BSD**
- **tests: drop umask tests after chmod-only refactor**
- **TESTS.md**
- **tests: Multi-byte paths**
- **Cache EPOCHSECONDS once before each loop**
- **tests: Cover setopt COMPLETE_ALIASES**
- **tests: setopt COMPLETE_ALIASES**
- **tests: Cross-reference stress.sh and test_concurrency.zsh**
